### PR TITLE
Don't allow changing sid from rehash.

### DIFF
--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -1624,19 +1624,8 @@ void applymeblock(void)
 	if (!*me.name)
 		strlcpy(me.name, conf_me->name, sizeof(me.name));
 
-	/* SID change? */
-	if (strcmp(me.id, conf_me->sid))
-	{
-		/* Can we apply ? */
-		if (!isanyserverlinked())
-		{
-			strlcpy(me.id, conf_me->sid, sizeof(me.id));
-		} else {
-			config_warn("me::sid: Server ID changed in config but this change cannot be applied "
-			            "due to being linked to other servers. Unlink all servers and /REHASH to "
-			            "try again.");
-		}
-	}
+	if (!*me.id)
+		strlcpy(me.id, conf_me->sid, sizeof(me.id));
 }
 
 int	init_conf(char *rootconf, int rehash)


### PR DESCRIPTION
Not sure how this was supposed to originally work, if the sid is changed
the uid generator is not re-initied, and even if it was it would allow
id collisions if it ever uplinked to another ircd with the old id it
had.

I see no reason for this.
