### PR TITLE
Fix build with LibreSSL

### DIFF
--- a/configure
+++ b/configure
@@ -3868,6 +3868,53 @@ fi
 
 
 
+ 
+ 
+ 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for RAND_egd in -lcrypto" >&5
+$as_echo_n "checking for RAND_egd in -lcrypto... " >&6; }
+if ${ac_cv_lib_crypto_RAND_egd+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lcrypto  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char RAND_egd ();
+int
+main ()
+{
+return RAND_egd ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_crypto_RAND_egd=yes
+else
+  ac_cv_lib_crypto_RAND_egd=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_crypto_RAND_egd" >&5
+$as_echo "$ac_cv_lib_crypto_RAND_egd" >&6; }
+if test "x$ac_cv_lib_crypto_RAND_egd" = xyes; then :
+
+$as_echo "#define HAVE_RAND_EGD 1" >>confdefs.h
+
+fi
+ 
+ 
+ 
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -93,6 +93,8 @@ AC_CHECK_LIB(socket, socket,
 AC_CHECK_LIB(nsl, inet_ntoa,
 	[IRCDLIBS="$IRCDLIBS-lnsl "
 		INETLIB="-lnsl"])
+AC_CHECK_LIB(crypto, RAND_egd,
+		AC_DEFINE(HAVE_RAND_EGD, 1, [Define if the libcrypto has RAND_egd]))
 
 AC_SUBST(IRCDLIBS)
 AC_SUBST(MKPASSWDLIBS)

--- a/include/dynconf.h
+++ b/include/dynconf.h
@@ -193,7 +193,11 @@ extern MODVAR aConfiguration iConf;
 #define SHOWCONNECTINFO			iConf.show_connect_info
 #define OPER_ONLY_STATS			iConf.oper_only_stats
 #define ANTI_SPAM_QUIT_MSG_TIME		iConf.anti_spam_quit_message_time
+#ifdef HAVE_RAND_EGD
 #define USE_EGD				iConf.use_egd
+#else
+#define USE_EGD				0
+#endif
 #define EGD_PATH			iConf.egd_path
 
 #define ircnetwork			iConf.network.x_ircnetwork

--- a/src/random.c
+++ b/src/random.c
@@ -185,7 +185,7 @@ MEMORYSTATUS mstat;
 
 	/* Grab non-OS specific "random" data */
 #ifdef USE_SSL
- #if OPENSSL_VERSION_NUMBER >= 0x000907000
+ #if OPENSSL_VERSION_NUMBER >= 0x000907000 && defined(HAVE_RAND_EGD)
 	if (EGD_PATH) {
 		RAND_query_egd_bytes(EGD_PATH, rdat.egd, sizeof(rdat.egd));
 	}


### PR DESCRIPTION
LibreSSL has removed RAND_egd completely, this patch adds RAND_egd
detection to configure and adds HAVE_RAND_EGD checks to the code where
required.

Please consider removing EGD support completely, there's no OS that does not have a proper source of random for many years.
