### PR TITLE
[#3539]: Fixes sending empty messages being sent if a message containing only control codes is sent to the channel with stripcolor channel mode set

### DIFF
--- a/src/modules/m_message.c
+++ b/src/modules/m_message.c
@@ -777,6 +777,8 @@ char *_StripColors(unsigned char *text) {
 		len--;
 	}
 	new_str[i] = 0;
+	if (new_str[0] == '\0')
+		return NULL;
 	return new_str;
 }
 


### PR DESCRIPTION
We should send ERR_NOTEXTTOSEND too.