### PR TITLE
Fork safety

### DIFF
--- a/include/fdlist.h
+++ b/include/fdlist.h
@@ -39,6 +39,5 @@ extern int fd_fileopen(const char *path, unsigned int flags);
 extern void fd_setselect(int fd, int flags, IOCallbackFunc iocb, void *data);
 extern void fd_select(time_t delay);		/* backend-specific */
 extern void fd_refresh(int fd);			/* backend-specific */
-extern void fd_fork(); /* backend-specific */
 
 #endif

--- a/src/ircd.c
+++ b/src/ircd.c
@@ -1394,6 +1394,7 @@ int InitUnrealIRCd(int argc, char *argv[])
 #endif
 	fprintf(stderr, "\n");
 #endif
+
 	clear_client_hash_table();
 	clear_channel_hash_table();
 	clear_watch_hash_table();
@@ -1455,6 +1456,14 @@ int InitUnrealIRCd(int argc, char *argv[])
 #ifndef _WIN32
 	fprintf(stderr, "Dynamic configuration initialized.. booting IRCd.\n");
 #endif
+#if !defined(_AMIGA) && !defined(_WIN32) && !defined(NO_FORKING)
+	if (!(bootopt & BOOT_NOFORK))
+	{
+		if (fork())
+			exit(0);
+		loop.ircd_forked = 1;
+	}
+#endif
 	open_debugfile();
 	if (portnum < 0)
 		portnum = PORTNUM;
@@ -1494,15 +1503,7 @@ int InitUnrealIRCd(int argc, char *argv[])
 	(void)add_to_client_hash_table(me.name, &me);
 	(void)add_to_id_hash_table(me.id, &me);
 	list_add(&me.client_node, &global_server_list);
-#if !defined(_AMIGA) && !defined(_WIN32) && !defined(NO_FORKING)
-	if (!(bootopt & BOOT_NOFORK))
-	{
-		if (fork())
-			exit(0);
-    fd_fork();
-		loop.ircd_forked = 1;
-	}
-#endif
+
 	(void)ircsnprintf(REPORT_DO_DNS, sizeof(REPORT_DO_DNS), ":%s %s", me.name, BREPORT_DO_DNS);
 	(void)ircsnprintf(REPORT_FIN_DNS, sizeof(REPORT_FIN_DNS), ":%s %s", me.name, BREPORT_FIN_DNS);
 	(void)ircsnprintf(REPORT_FIN_DNSC, sizeof(REPORT_FIN_DNSC), ":%s %s", me.name, BREPORT_FIN_DNSC);

--- a/src/ircd.c
+++ b/src/ircd.c
@@ -82,7 +82,7 @@ LoopStruct loop;
 MODVAR MemoryInfo StatsZ;
 #ifndef _WIN32
 uid_t irc_uid = 0;
-gid_t irc_gid = 0;
+gid_t irc_gid = 0; 
 #endif
 
 int  R_do_dns, R_fin_dns, R_fin_dnsc, R_fail_dns, R_do_id, R_fin_id, R_fail_id;
@@ -197,7 +197,7 @@ VOIDSIG s_die()
 	else {
 		SERVICE_STATUS status;
 		SC_HANDLE hSCManager = OpenSCManager(NULL, NULL, SC_MANAGER_ALL_ACCESS);
-		SC_HANDLE hService = OpenService(hSCManager, "UnrealIRCd", SERVICE_STOP);
+		SC_HANDLE hService = OpenService(hSCManager, "UnrealIRCd", SERVICE_STOP); 
 		ControlService(hService, SERVICE_CONTROL_STOP, &status);
 	}
 #else
@@ -242,7 +242,7 @@ VOIDSIG s_restart()
 
 	if (restarting == 0) {
 		/*
-		 * Send (or attempt to) a dying scream to oper if present
+		 * Send (or attempt to) a dying scream to oper if present 
 		 */
 
 		restarting = 1;
@@ -339,7 +339,7 @@ void server_reboot(char *mesg)
 		IRCDStatus.dwCurrentState = SERVICE_STOP_PENDING;
 		SetServiceStatus(IRCDStatusHandle, &IRCDStatus);
 		GetModuleFileName(GetModuleHandle(NULL), fname, MAX_PATH);
-		CreateProcess(fname, "restartsvc", NULL, NULL, FALSE,
+		CreateProcess(fname, "restartsvc", NULL, NULL, FALSE, 
 			0, NULL, NULL, &si, &pi);
 		IRCDStatus.dwCurrentState = SERVICE_STOPPED;
 		SetServiceStatus(IRCDStatusHandle, &IRCDStatus);
@@ -409,7 +409,7 @@ EVENT(try_connections)
 			continue;
 
 		class = aconf->class;
-
+		
 		/* Only do one connection attempt per <connfreq> seconds (for the same server) */
 		if ((aconf->hold > TStime()))
 			continue;
@@ -546,7 +546,7 @@ int check_ping(aClient *cptr)
 	Debug((DEBUG_DEBUG, "c(%s)=%d p %d a %d", cptr->name,
 		cptr->status, ping,
 		TStime() - cptr->local->lasttime));
-
+	
 	/* If ping is less than or equal to the last time we received a command from them */
 	if (ping > (TStime() - cptr->local->lasttime))
 		return 0; /* some recent command was executed */
@@ -556,7 +556,7 @@ int check_ping(aClient *cptr)
 		((cptr->flags & FLAGS_PINGSENT)
 		/* And they had 2x ping frequency to respond */
 		&& ((TStime() - cptr->local->lasttime) >= (2 * ping)))
-		||
+		|| 
 		/* Or isn't registered and time spent is larger than ping (CONNECTTIMEOUT).. */
 		(!IsRegistered(cptr) && (TStime() - cptr->local->since >= ping))
 		)
@@ -589,12 +589,12 @@ int check_ping(aClient *cptr)
 		 */
 		cptr->flags |= FLAGS_PINGSENT;
 		/*
-		 * not nice but does the job
+		 * not nice but does the job 
 		 */
 		cptr->local->lasttime = TStime() - ping;
 		sendto_one(cptr, "PING :%s", me.name);
 	}
-
+	
 	return 0;
 }
 
@@ -620,7 +620,7 @@ EVENT(check_pings)
 	{
 		check_ping(cptr);
 	}
-
+	
 	loop.do_bancheck = loop.do_bancheck_spamf_user = loop.do_bancheck_spamf_away = 0;
 	/* done */
 }
@@ -628,7 +628,7 @@ EVENT(check_pings)
 EVENT(check_deadsockets)
 {
 	aClient *cptr, *cptr2;
-
+	
 	list_for_each_entry_safe(cptr, cptr2, &unknown_list, lclient_node)
 	{
 		/* No need to notify opers here. It's already done when "FLAGS_DEADSOCKET" is set. */
@@ -702,7 +702,7 @@ static void version_check_logerror(char *fmt, ...)
 {
 va_list va;
 char buf[1024];
-
+	
 	va_start(va, fmt);
 	vsnprintf(buf, sizeof(buf), fmt, va);
 	va_end(va);
@@ -710,7 +710,7 @@ char buf[1024];
 	fprintf(stderr, "[!!!] %s\n", buf);
 #else
 	win_log("[!!!] %s", buf);
-#endif
+#endif	
 }
 
 /** Ugly version checker that ensures ssl/curl runtime libraries match the
@@ -735,7 +735,7 @@ static void do_version_check()
 		if (p)
 		{
 			int versionlen = p - compiledfor + 1;
-
+			
 			if (strncasecmp(compiledfor, runtime, versionlen))
 			{
 				version_check_logerror("OpenSSL version mismatch: compiled for '%s', library is '%s'",
@@ -744,8 +744,8 @@ static void do_version_check()
 			}
 		}
 	}
-
-
+	
+	
 #ifdef USE_LIBCURL
 	/* Perhaps someone should tell them to do this a bit more easy ;)
 	 * problem is runtime output is like: 'libcurl/7.11.1 c-ares/1.2.0'
@@ -753,7 +753,7 @@ static void do_version_check()
 	 */
 	{
 		char buf[128], *p;
-
+		
 		runtime = curl_version();
 		compiledfor = LIBCURL_VERSION;
 		if (!strncmp(runtime, "libcurl/", 8))
@@ -847,7 +847,7 @@ void fix_timers(void)
 					acptr->name, acptr->local->nexttarget, TStime()));
 				acptr->local->nexttarget = TStime();
 			}
-
+			
 		}
 	}
 
@@ -1017,7 +1017,7 @@ int InitUnrealIRCd(int argc, char *argv[])
 			"         giving a cracker root SSH access to your box.\n"
 			"         You should either start UnrealIRCd under a different\n"
 			"         account than root, or set IRC_USER in include/config.h\n"
-			"         to a nonprivileged username and recompile.\n");
+			"         to a nonprivileged username and recompile.\n"); 
 		sleep(1); /* just to catch their attention */
 	}
 #endif /* IRC_USER */
@@ -1055,7 +1055,7 @@ int InitUnrealIRCd(int argc, char *argv[])
 	{
 		struct stat sb;
 		mode_t umaskold;
-
+		
 		umaskold = umask(0);
 		if (mkdir("dev", S_IRUSR|S_IWUSR|S_IXUSR|S_IXGRP|S_IXOTH) != 0 && errno != EEXIST)
 		{
@@ -1365,10 +1365,10 @@ int InitUnrealIRCd(int argc, char *argv[])
 #endif
 #ifndef _WIN32
 	/*
-	 * didn't set debuglevel
+	 * didn't set debuglevel 
 	 */
 	/*
-	 * but asked for debugging output to tty
+	 * but asked for debugging output to tty 
 	 */
 	if ((debuglevel < 0) && (bootopt & BOOT_TTY)) {
 		(void)fprintf(stderr,
@@ -1410,7 +1410,7 @@ int InitUnrealIRCd(int argc, char *argv[])
 #endif
 	init_dynconf();
 	/*
-	 * Add default class
+	 * Add default class 
 	 */
 	default_class =
 	    (ConfigItem_class *) MyMallocEx(sizeof(ConfigItem_class));
@@ -1433,7 +1433,7 @@ int InitUnrealIRCd(int argc, char *argv[])
 	clicap_init();
 	if (!find_Command_simple("AWAY") /*|| !find_Command_simple("KILL") ||
 		!find_Command_simple("OPER") || !find_Command_simple("PING")*/)
-	{
+	{ 
 		config_error("Someone forgot to load modules with proper commands in them. READ THE DOCUMENTATION");
 		exit(-4);
 	}
@@ -1494,7 +1494,7 @@ int InitUnrealIRCd(int argc, char *argv[])
 	me.from = &me;
 
 	/*
-	 * This listener will never go away
+	 * This listener will never go away 
 	 */
 	me_hash = find_or_add(me.name);
 	me.serv->up = me_hash;
@@ -1553,8 +1553,8 @@ void SocketLoop(void *dummy)
 	TS   delay = 0;
 	static TS lastglinecheck = 0;
 	TS   last_tune;
-
-
+	
+	
 	while (1)
 #else
 	/*
@@ -1639,13 +1639,13 @@ void SocketLoop(void *dummy)
 			IRCstats.me_max = IRCstats.me_clients;
 
 		fd_select(SOCKETLOOP_MAX_DELAY);
-
+		
 		process_clients();
-
+		
 		timeofday = time(NULL) + TSoffset;
 
 		/*
-		 * Debug((DEBUG_DEBUG, "Got message(s)"));
+		 * Debug((DEBUG_DEBUG, "Got message(s)")); 
 		 */
 		/*
 		 * ** ...perhaps should not do these loops every time,
@@ -1655,7 +1655,7 @@ void SocketLoop(void *dummy)
 		 * ** time might be too far away... (similarly with
 		 * ** ping times) --msa
 		 */
-		if (dorehash)
+		if (dorehash) 
 		{
 			(void)rehash(&me, &me, 1);
 			dorehash = 0;
@@ -1697,7 +1697,7 @@ static void open_debugfile(void)
 			if ((fd = open(LOGFILE, O_WRONLY | O_CREAT, 0600)) < 0)
 				if ((fd = open("/dev/null", O_WRONLY)) < 0)
 					exit(-1);
-
+			
 #if 1
 			cptr->fd = fd;
 			debugfd = fd;

--- a/src/s_dispatch.c
+++ b/src/s_dispatch.c
@@ -270,10 +270,6 @@ void fd_select(time_t delay)
 	}
 }
 
-void fd_fork()
-{
-}
-
 #endif
 
 /***************************************************************************************
@@ -285,47 +281,21 @@ void fd_fork()
 
 static int kqueue_fd = -1;
 static struct kevent kqueue_events[MAXCONNECTIONS * 2];
-static struct kevent kqueue_prepared[MAXCONNECTIONS * 2];
-static char kqueue_enabled[MAXCONNECTIONS * 2];
-
-void fd_fork()
-{
-	kqueue_fd = kqueue();
-	int p;
-
-	for (p=0; p < MAXCONNECTIONS * 2; ++p)
-	{
-		if (kqueue_enabled[p])
-		{
-			if (kevent(kqueue_fd, &kqueue_prepared[p], 1, NULL, 0, &(const struct timespec){ .tv_sec = 0, .tv_nsec = 0}) != 0)
-			{
-				if (ERRNO == P_EWOULDBLOCK || ERRNO == P_EAGAIN)
-					continue;
-					
-				ircd_log(LOG_ERROR, "[BUG?] kevent returned %d", errno);
-			}
-		}
-	}
-}
 
 void fd_refresh(int fd)
 {
+	struct kevent ev;
 	FDEntry *fde = &fd_table[fd];
 
 	if (kqueue_fd == -1)
-	{
 		kqueue_fd = kqueue();
-		memset(kqueue_enabled,0,MAXCONNECTIONS*2);
-	}
 
 	fde->backend_flags = 0;
-	kqueue_enabled[fd] = 0;
-	kqueue_enabled[fd+MAXCONNECTIONS] = 0;
 
 	if (fde->read_callback != NULL || fde->backend_flags & EVFILT_READ)
 	{
-		EV_SET(&kqueue_prepared[fd], (uintptr_t) fd, (short) EVFILT_READ, fde->read_callback != NULL ? EV_ADD : EV_DELETE, 0, 0, fde);
-		if (kevent(kqueue_fd, &kqueue_prepared[fd], 1, NULL, 0, &(const struct timespec){ .tv_sec = 0, .tv_nsec = 0}) != 0)
+		EV_SET(&ev, (uintptr_t) fd, (short) EVFILT_READ, fde->read_callback != NULL ? EV_ADD : EV_DELETE, 0, 0, fde);
+		if (kevent(kqueue_fd, &ev, 1, NULL, 0, &(const struct timespec){ .tv_sec = 0, .tv_nsec = 0}) != 0)
 		{
 			if (ERRNO == P_EWOULDBLOCK || ERRNO == P_EAGAIN)
 				return;
@@ -337,8 +307,8 @@ void fd_refresh(int fd)
 
 	if (fde->write_callback != NULL || fde->backend_flags & EVFILT_WRITE)
 	{
-		EV_SET(&kqueue_prepared[fd+MAXCONNECTIONS], (uintptr_t) fd, (short) EVFILT_WRITE, fde->write_callback != NULL ? EV_ADD : EV_DELETE, 0, 0, fde);
-		if (kevent(kqueue_fd, &kqueue_prepared[fd+MAXCONNECTIONS], 1, NULL, 0, &(const struct timespec){ .tv_sec = 0, .tv_nsec = 0}) != 0)
+		EV_SET(&ev, (uintptr_t) fd, (short) EVFILT_WRITE, fde->write_callback != NULL ? EV_ADD : EV_DELETE, 0, 0, fde);
+		if (kevent(kqueue_fd, &ev, 1, NULL, 0, &(const struct timespec){ .tv_sec = 0, .tv_nsec = 0}) != 0)
 		{
 			if (ERRNO == P_EWOULDBLOCK || ERRNO == P_EAGAIN)
 				return;
@@ -349,17 +319,10 @@ void fd_refresh(int fd)
 	}
 
 	if (fde->read_callback != NULL)
-	{
 		fde->backend_flags |= EVFILT_READ;
-		kqueue_enabled[fd] = 1;
-
-	}
 
 	if (fde->write_callback != NULL)
-	{
 		fde->backend_flags |= EVFILT_WRITE;
-		kqueue_enabled[fd+MAXCONNECTIONS] = 1;
-	}
 }
 
 void fd_select(time_t delay)
@@ -369,10 +332,7 @@ void fd_select(time_t delay)
 	struct kevent *ke;
 
 	if (kqueue_fd == -1)
-	{
 		kqueue_fd = kqueue();
-		memset(kqueue_enabled,0,MAXCONNECTIONS*2);
-	}
 
 	ts.tv_sec = delay / 1000;
 	ts.tv_nsec = delay % 1000 * 1000000;
@@ -417,6 +377,7 @@ void fd_select(time_t delay)
 		}
 	}
 }
+
 #endif
 
 /***************************************************************************************
@@ -571,11 +532,6 @@ void fd_select(time_t delay)
 #endif
 }
 
-
-void fd_fork()
-{
-}
-
 #endif
 
 /***************************************************************************************
@@ -672,11 +628,6 @@ void fd_select(time_t delay)
 			fde->write_oneshot = 0;
 		}
 	}
-}
-
-
-void fd_fork()
-{
 }
 
 #endif


### PR DESCRIPTION
This pull request moves fork() to a logically better place and removes several other problems associated with the current location of fork(), by ensuring that it is at a point in the program where no asynchronous failure conditions can occur.

Additionally, it has been load tested on Windows, Mac OS X, Linux (both glibc and musl), FreeBSD and Solaris.

It is an extremely low risk merge.

Signed-off-by: William Pitcock <nenolod@dereferenced.org>