### PR TITLE
Allow shunned users to use the PING command

### DIFF
--- a/src/modules/m_pingpong.c
+++ b/src/modules/m_pingpong.c
@@ -59,7 +59,7 @@ ModuleHeader MOD_HEADER(m_pingpong)
 /* This is called on module init, before Server Ready */
 MOD_INIT(m_pingpong)
 {
-	CommandAdd(modinfo->handle, MSG_PING, m_ping, MAXPARA, M_USER|M_SERVER);
+	CommandAdd(modinfo->handle, MSG_PING, m_ping, MAXPARA, M_USER|M_SERVER|M_SHUN);
 	CommandAdd(modinfo->handle, MSG_PONG, m_pong, MAXPARA, M_UNREGISTERED|M_USER|M_SERVER|M_SHUN|M_VIRUS);
 	MARK_AS_OFFICIAL_MODULE(modinfo);
 	return MOD_SUCCESS;


### PR DESCRIPTION
When a user is shunned (eg /tempshun user ), the command PING cannot be used (while PONG can, to answer server PING).
Some clients like irssi are using PING  command to compute the server lag, so when an irssi user is shunned, the lag displayed in irssi start to increase, giving the user a way to know if he is shunned.
After 320 sec of lag, irssi will reconnect, bypassing automatically the tempshun.