### PR TITLE
build: Install the run script in the base dir

### DIFF
--- a/Config
+++ b/Config
@@ -3,7 +3,7 @@
 # Config script for UnrealIRCd
 # (C) 2001 The UnrealIRCd Team
 #
-# This configure script is free software; the UnrealIRCd Team gives 
+# This configure script is free software; the UnrealIRCd Team gives
 # unlimited permission to copy, distribute and modify as long as the
 # copyright headers stay intact
 #
@@ -22,7 +22,7 @@
 RUN_CONFIGURE () {
 ARG=" "
 
-if [ -z "$BINDIR" -o -z "$DATADIR" -o -z "$CONFDIR" -o -z "$MODULESDIR" -o -z "$LOGDIR" -o -z "$CACHEDIR" -o -z "$DOCDIR" -o -z "$TMPDIR" ]; then
+if [ -z "$BINDIR" -o -z "$DATADIR" -o -z "$CONFDIR" -o -z "$MODULESDIR" -o -z "$LOGDIR" -o -z "$CACHEDIR" -o -z "$DOCDIR" -o -z "$TMPDIR" -o -z "$SCRIPTDIR" ]; then
 	echo "Sorry './Config -quick' cannot be used because your 'config.settings'"
 	echo "file either does not exist or is from an old UnrealIRCd version"
 	echo "(older than version 3.4-alpha4)."
@@ -78,6 +78,7 @@ ARG="$ARG--with-logdir=$LOGDIR "
 ARG="$ARG--with-cachedir=$CACHEDIR "
 ARG="$ARG--with-docdir=$DOCDIR "
 ARG="$ARG--with-tmpdir=$TMPDIR "
+ARG="$ARG--with-scriptdir=$SCRIPTDIR "
 
 ARG="$ARG--with-nick-history=$NICKNAMEHISTORYLENGTH "
 ARG="$ARG--with-sendq=$MAXSENDQLENGTH "
@@ -515,6 +516,7 @@ LOGDIR="$BASEPATH/logs"
 CACHEDIR="$BASEPATH/cache"
 DOCDIR="$BASEPATH/doc"
 TMPDIR="$BASEPATH/tmp"
+SCRIPTDIR="$BASEPATH"
 
 TEST=""
 while [ -z "$TEST" ] ; do
@@ -549,7 +551,7 @@ echo $n "[$TEST] -> $c"
     read cc
 if [ -z "$cc" ] ; then
     SSLDIR="$TEST"
-else 
+else
     SSLDIR=`eval echo $cc` # modified
 fi
 
@@ -619,11 +621,11 @@ if [ "$REMOTEINC" = "1" ] ; then
                           CURLDIR=""
                   fi
                 fi
-                
+
                 # Second, use the local curl if it exists (overrides above)
                 if [ -d "$HOME/curl" ]; then
                         CURLDIR="$HOME/curl"
-                        
+
                         # Check if it's recent enough...
                         # But first, check if curl-config can be trusted at all: it depends
                         # on 'bc' for some reason and not all systems have that installed!
@@ -670,13 +672,13 @@ if [ "$REMOTEINC" = "1" ] ; then
                             fi
                         fi
                 fi
-                
+
                 # Need to output it here, as the HOME check from above may cause this to be no longer relevant.
                 if [ "x$CURLDIR" = "x" -a "$GOTASYNC" != "1" ]; then
                 	echo "Curl library was found in $PREVCURLDIR, but it does not support Asynchronous DNS (not compiled with c-ares)"
                 	echo "so it's of no use to us."
                 fi
-                	
+
         fi
         if [ "x$CURLDIR" = "x" ]; then
         	# Still empty?
@@ -855,6 +857,7 @@ LOGDIR="$LOGDIR"
 CACHEDIR="$CACHEDIR"
 DOCDIR="$DOCDIR"
 TMPDIR="$TMPDIR"
+SCRIPTDIR="$SCRIPTDIR"
 PREFIXAQ="$PREFIXAQ"
 MAXSENDQLENGTH="$MAXSENDQLENGTH"
 MAXCONNECTIONS="$MAXCONNECTIONS"

--- a/Makefile.in
+++ b/Makefile.in
@@ -15,7 +15,7 @@
 #*   You should have received a copy of the GNU General Public License
 #*   along with this program; if not, write to the Free Software
 #*   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-#*  
+#*
 #*   $Id$
 #*/
 
@@ -57,7 +57,7 @@ XCFLAGS=@PTHREAD_CFLAGS@ @TRE_CFLAGS@ @PCRE2_CFLAGS@ @CARES_CFLAGS@ @CFLAGS@
 # Dynix/ptx V2.0.x
 #CFLAGS= -I$(INCLUDEDIR) -O -Xo
 #IRCDLIBS= -lsocket -linet -lnsl -lseq
-# 
+#
 # Dynix/ptx V1.x.x
 #IRCDLIBS= -lsocket -linet -lnsl -lseq
 #
@@ -86,7 +86,7 @@ XCFLAGS=@PTHREAD_CFLAGS@ @TRE_CFLAGS@ @PCRE2_CFLAGS@ @CARES_CFLAGS@ @CFLAGS@
 # The 4 at the front is important (allows for setuidness)
 #
 # WARNING: if you are making ircd SUID or SGID, check config.h to make sure
-#          you are not defining CMDLINE_CONFIG 
+#          you are not defining CMDLINE_CONFIG
 IRCDMODE = 711
 
 URL=@URL@
@@ -164,11 +164,11 @@ cleandir: clean
 	rm -rf include/setup.h Makefile Settings
 
 distclean: cleandir
-	rm -rf extras/*.bak extras/regexp extras/*.tar extras/c-ares 
+	rm -rf extras/*.bak extras/regexp extras/*.tar extras/c-ares
 	rm -rf extras/c-ares-* extras/tre-*
 	rm -rf config.log config.settings *.pem ircd.* unrealircd
 	rm -rf Makefile config.status
-	
+
 depend:
 	@+for i in $(SUBDIRS); do \
 		echo "Making dependencies in $$i";\
@@ -218,7 +218,7 @@ install: all
 	fi
 	@echo ''
 	@echo '* UnrealIRCd is now installed.'
-	
+
 	-@if [ "@SCRIPTDIR@/bin" = "@BINDIR@" ] ; then \
 		echo '* Leave this directory and run "cd @SCRIPTDIR@" now' ; \
 	fi
@@ -229,7 +229,7 @@ install: all
 	@echo '  * Configuration files: @CONFDIR@'
 	@echo '  * Log files: @LOGDIR@'
 	@echo '  * Modules: @MODULESDIR@'
-	@echo '* To start/stop UnrealIRCd run: @SCRIPTDIR@/unrealircd"'
+	@echo '* To start/stop UnrealIRCd run: "@SCRIPTDIR@/./unrealircd"'
 	@echo ''
 	@echo '* Consult the documentation online at:'
 	@echo '  * https://www.unrealircd.org/docs/UnrealIRCd_4_documentation'

--- a/configure.ac
+++ b/configure.ac
@@ -441,7 +441,7 @@ configuration files])],
 	dnl we assume that a user thinks that `chmod 0600 blah' is the same as `chmod 600 blah'
 	dnl (#3189)
 	[AC_DEFINE_UNQUOTED([DEFAULT_PERMISSIONS], [0$withval], [The default permissions for configuration files. Set to 0 to prevent unrealircd from calling chmod() on the files.])],
-	[AC_DEFINE([DEFAULT_PERMISSIONS], [0600], [The default permissions for configuration files. Set to 0 to prevent unrealircd from calling chmod() on the files.])]) 
+	[AC_DEFINE([DEFAULT_PERMISSIONS], [0600], [The default permissions for configuration files. Set to 0 to prevent unrealircd from calling chmod() on the files.])])
 
 AC_ARG_WITH(bindir, [AS_HELP_STRING([--with-bindir=path],[Specify the directory for the unrealircd binary])],
 	[AC_DEFINE_UNQUOTED([BINDIR], ["$withval"], [Define the directory where the unrealircd binary is located])

--- a/unrealircd.in
+++ b/unrealircd.in
@@ -144,7 +144,7 @@ elif [ "$1" = "backtrace" ] ; then
 	echo 'info sharedlibrary'|gdb @BINDIR@/unrealircd $corefile 2>/dev/null|\
 	grep No|grep tmp/|awk '{ print $2 }'|\
 	awk -F '.' "{ system(\"[ -f $modpath/\" \$2 \"/\" \$3 \".so ] && ln -s $modpath/\" \$2 \"/\" \$3 \".so \" \$0 \" || ln -s $modpath/\" \$2 \".so \" \$0) }"
-	
+
 	echo ""
 	echo "=================== START HERE ======================"
 	echo "BACKTRACE:"


### PR DESCRIPTION
As the readme suggests, by default place the start/stop
script in the same directory as the install

---
Per README:
`Run ./unrealircd start in the directory where you installed UnrealIRCd.`
However, it is installed in $HOME unless --with-scriptdir is passed to the configure script.
Also, under Makefile.in, I changed it so copy/pasting what `To start/stop UnrealIRCd run:` spits out will run. Apologies for the whitespace cleanups, my editor automatically does that :x. I can undo it if you'd like.