### PR TITLE
Add ability to hide quit messages of K/G/Z:lined users

### DIFF
--- a/doc/conf/examples/example.conf
+++ b/doc/conf/examples/example.conf
@@ -390,6 +390,7 @@ set {
 	options {
 		hide-ulines; /* hide U-lines in /MAP and /LINKS */
 		show-connect-info; /* show "looking up your hostname" messages on connect */
+		/* secret-ban-reasons; don't publicly display K/G/Z:lines reasons (in the QUIT message) */
 	};
 
 	maxchannelsperuser 10; /* maximum number of channels a user may /JOIN */

--- a/doc/conf/examples/example.fr.conf
+++ b/doc/conf/examples/example.fr.conf
@@ -413,6 +413,7 @@ set {
 	options {
 		hide-ulines; /* cacher les U-lines de /MAP et /LINKS */
 		show-connect-info; /* afficher les messages "looking up your hostname" à la connexion */
+		/* secret-ban-reasons; Ne pas afficher publiquement les raisons des K/G/Z:lines (dans le message de déconnexion (QUIT)) */
 	};
 
 	maxchannelsperuser 10; /* nombre max de salons par utilisateur */

--- a/doc/conf/examples/example.tr.conf
+++ b/doc/conf/examples/example.tr.conf
@@ -387,6 +387,7 @@ set {
 	options {
 		hide-ulines; /* U-lines satýrlarý /MAP ve /LINKS komutunda gözükmez */
 		show-connect-info; /* sunucuya baðlanýrken "looking up your hostname" mesajý görüntülenecektir */
+		/* secret-ban-reasons; don't publicly display K/G/Z:lines reasons (in the QUIT message) */
 	};
 
 	maxchannelsperuser 10; /* bir kullanýcýnýn maksimum girebileceði kanal sayýsý */

--- a/include/dynconf.h
+++ b/include/dynconf.h
@@ -64,6 +64,7 @@ struct zConfiguration {
 	unsigned dont_resolve:1;
 	unsigned use_ban_version:1;
 	unsigned mkpasswd_for_everyone:1;
+	unsigned secret_ban_reasons;
 	unsigned allow_insane_bans;
 	unsigned allow_part_if_shunned:1;
 	unsigned disable_cap:1;
@@ -217,6 +218,7 @@ extern MODVAR int ipv6_disabled;
 #define IDENT_READ_TIMEOUT		iConf.ident_read_timeout
 
 #define MKPASSWD_FOR_EVERYONE	iConf.mkpasswd_for_everyone
+#define SECRET_BAN_REASONS		iConf.secret_ban_reasons
 #define ALLOW_INSANE_BANS		iConf.allow_insane_bans
 #define CHANCMDPFX iConf.channel_command_prefix
 

--- a/src/modules/m_stats.c
+++ b/src/modules/m_stats.c
@@ -1257,6 +1257,8 @@ int stats_set(aClient *sptr, char *para)
 	    sptr->name, DONT_RESOLVE);
 	sendto_one(sptr, ":%s %i %s :options::mkpasswd-for-everyone: %d", me.name, RPL_TEXT,
 	    sptr->name, MKPASSWD_FOR_EVERYONE);
+	sendto_one(sptr, ":%s %i %s :options::secret-ban-reasons: %d", me.name, RPL_TEXT,
+	    sptr->name, SECRET_BAN_REASONS);
 	sendto_one(sptr, ":%s %i %s :options::allow-insane-bans: %d", me.name, RPL_TEXT,
 	    sptr->name, ALLOW_INSANE_BANS);
 	sendto_one(sptr, ":%s %i %s :options::allow-part-if-shunned: %d", me.name, RPL_TEXT,

--- a/src/modules/m_tkl.c
+++ b/src/modules/m_tkl.c
@@ -1198,9 +1198,15 @@ int  _find_tkline_match(aClient *cptr, int xx)
 				           me.name, cptr->name,
 				           (lp->expire_at ? "banned" : "permanently banned"),
 				           ircnetwork, lp->reason);
-			ircsnprintf(msge, sizeof(msge), "User has been %s from %s (%s)",
-			            (lp->expire_at ? "banned" : "permanently banned"),
-			            ircnetwork, lp->reason);
+						   
+			if (SECRET_BAN_REASONS)
+				ircsnprintf(msge, sizeof(msge), "User has been %s from %s",
+							(lp->expire_at ? "banned" : "permanently banned"),
+							ircnetwork);
+			else
+				ircsnprintf(msge, sizeof(msge), "User has been %s from %s (%s)",
+							(lp->expire_at ? "banned" : "permanently banned"),
+							ircnetwork, lp->reason);
 			return exit_client(cptr, cptr, &me, msge);
 		}
 		else
@@ -1210,9 +1216,13 @@ int  _find_tkline_match(aClient *cptr, int xx)
 			           me.name, cptr->name,
 			           (lp->expire_at ? "banned" : "permanently banned"),
 			           me.name, lp->reason, KLINE_ADDRESS);
-			ircsnprintf(msge, sizeof(msge), "User is %s (%s)",
-			           (lp->expire_at ? "banned" : "permanently banned"),
-			           lp->reason);
+			if (SECRET_BAN_REASONS)
+				ircsnprintf(msge, sizeof(msge), "User is %s",
+						   (lp->expire_at ? "banned" : "permanently banned"));
+			else
+				ircsnprintf(msge, sizeof(msge), "User is %s (%s)",
+						   (lp->expire_at ? "banned" : "permanently banned"),
+						   lp->reason);
 			return exit_client(cptr, cptr, &me, msge);
 
 		}
@@ -1220,7 +1230,10 @@ int  _find_tkline_match(aClient *cptr, int xx)
 	if (lp->type & TKL_ZAP)
 	{
 		ircstp->is_ref++;
-		ircsnprintf(msge, sizeof(msge), "Z:lined (%s)",lp->reason);
+		if (SECRET_BAN_REASONS && IsRegistered(cptr))
+			msge = "Z:lined";
+		else
+			ircsnprintf(msge, sizeof(msge), "Z:lined (%s)",lp->reason);
 		return exit_client(cptr, cptr, &me, msge);
 	}
 

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -6920,6 +6920,9 @@ int	_conf_set(ConfigFile *conf, ConfigEntry *ce)
 				else if (!strcmp(cepp->ce_varname, "mkpasswd-for-everyone")) {
 					tempiConf.mkpasswd_for_everyone = 1;
 				}
+				else if (!strcmp(cepp->ce_varname, "secret-ban-reasons")) {
+					tempiConf.secret_ban_reasons = 1;
+				}
 				else if (!strcmp(cepp->ce_varname, "allow-insane-bans")) {
 					tempiConf.allow_insane_bans = 1;
 				}
@@ -7679,6 +7682,9 @@ int	_test_set(ConfigFile *conf, ConfigEntry *ce)
 				}
 				else if (!strcmp(cepp->ce_varname, "mkpasswd-for-everyone")) {
 					CheckDuplicate(cepp, options_mkpasswd_for_everyone, "options::mkpasswd-for-everyone");
+				}
+				else if (!strcmp(cepp->ce_varname, "secret-ban-reasons")) {
+					CheckDuplicate(cepp, options_secret_ban_reasons, "options::secret-ban-reasons");
 				}
 				else if (!strcmp(cepp->ce_varname, "allow-insane-bans")) {
 					CheckDuplicate(cepp, options_allow_insane_bans, "options::allow-insane-bans");


### PR DESCRIPTION
This add `set::options::secret-ban-reasons` in the configuration file

Suggested by Aubrey ([#3993](https://bugs.unrealircd.org/view.php?id=3993))