### PR TITLE
Add an option to hide the notices about TLS parameters

### DIFF
--- a/include/dynconf.h
+++ b/include/dynconf.h
@@ -61,6 +61,7 @@ struct zConfiguration {
 	unsigned ident_check:1;
 	unsigned fail_oper_warn:1;
 	unsigned show_connect_info:1;
+	unsigned no_connect_ssl_info:1;
 	unsigned dont_resolve:1;
 	unsigned use_ban_version:1;
 	unsigned mkpasswd_for_everyone:1;
@@ -170,6 +171,7 @@ extern MODVAR int ipv6_disabled;
 #define IDENT_CHECK			iConf.ident_check
 #define FAILOPER_WARN			iConf.fail_oper_warn
 #define SHOWCONNECTINFO			iConf.show_connect_info
+#define NOCONNECTSSLINFO		iConf.no_connect_ssl_info
 #define OPER_ONLY_STATS			iConf.oper_only_stats
 #define ANTI_SPAM_QUIT_MSG_TIME		iConf.anti_spam_quit_message_time
 #ifdef HAVE_RAND_EGD
@@ -349,6 +351,7 @@ struct SetCheck {
 	unsigned has_options_fail_oper_warn:1;
 	unsigned has_options_dont_resolve:1;
 	unsigned has_options_show_connect_info:1;
+	unsigned has_options_no_connect_ssl_info:1;
 	unsigned has_options_mkpasswd_for_everyone:1;
 	unsigned has_options_allow_insane_bans:1;
 	unsigned has_options_allow_part_if_shunned:1;

--- a/src/modules/certfp.c
+++ b/src/modules/certfp.c
@@ -123,7 +123,7 @@ int certfp_connect(aClient *acptr)
 	{
 		char *fp = moddata_client_get(acptr, "certfp");
 	
-		if (fp)
+		if (fp && !iConf.no_connect_ssl_info)
 			sendnotice(acptr, "*** Your SSL fingerprint is %s", fp);
 	}
 

--- a/src/modules/m_nick.c
+++ b/src/modules/m_nick.c
@@ -1413,7 +1413,7 @@ int _register_user(aClient *cptr, aClient *sptr, char *nick, char *username, cha
 
 		if (sptr->flags & FLAGS_SSL)
 		{
-			if (sptr->local->ssl)
+			if (sptr->local->ssl && !iConf.no_connect_ssl_info)
 			{
 				sendto_one(sptr,
 				    ":%s NOTICE %s :*** You are connected to %s with %s",

--- a/src/modules/m_stats.c
+++ b/src/modules/m_stats.c
@@ -1236,6 +1236,8 @@ int stats_set(aClient *sptr, char *para)
 	    sptr->name, FAILOPER_WARN);
 	sendto_one(sptr, ":%s %i %s :options::show-connect-info: %d", me.name, RPL_TEXT,
 	    sptr->name, SHOWCONNECTINFO);
+	sendto_one(sptr, ":%s %i %s :options::no-connect-ssl-info: %d", me.name, RPL_TEXT,
+	    sptr->name, NOCONNECTSSLINFO);
 	sendto_one(sptr, ":%s %i %s :options::dont-resolve: %d", me.name, RPL_TEXT,
 	    sptr->name, DONT_RESOLVE);
 	sendto_one(sptr, ":%s %i %s :options::mkpasswd-for-everyone: %d", me.name, RPL_TEXT,

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -6922,6 +6922,9 @@ int	_conf_set(ConfigFile *conf, ConfigEntry *ce)
 				else if (!strcmp(cepp->ce_varname, "show-connect-info")) {
 					tempiConf.show_connect_info = 1;
 				}
+				else if (!strcmp(cepp->ce_varname, "no-connect-ssl-info")) {
+					tempiConf.no_connect_ssl_info = 1;
+				}
 				else if (!strcmp(cepp->ce_varname, "dont-resolve")) {
 					tempiConf.dont_resolve = 1;
 				}
@@ -7680,6 +7683,9 @@ int	_test_set(ConfigFile *conf, ConfigEntry *ce)
 				}
 				else if (!strcmp(cepp->ce_varname, "show-connect-info")) {
 					CheckDuplicate(cepp, options_show_connect_info, "options::show-connect-info");
+				}
+				else if (!strcmp(cepp->ce_varname, "no-connect-ssl-info")) {
+					CheckDuplicate(cepp, options_no_connect_ssl_info, "options::no-connect-ssl-info");
 				}
 				else if (!strcmp(cepp->ce_varname, "dont-resolve")) {
 					CheckDuplicate(cepp, options_dont_resolve, "options::dont-resolve");


### PR DESCRIPTION
I don't like my servers being overly verbose. The fingerprint can be seen in one's own /whois anyway.