### PR TITLE
Fix typos ("success" instead of "succes")

### DIFF
--- a/doc/Changes.old
+++ b/doc/Changes.old
@@ -1543,7 +1543,7 @@
 - Fixed CHROOTDIR, which was broken in 3.2.7: IRC_USER/IRC_GROUP did not work
   properly when CHROOTDIR was in use (#0003454).
 - Fixed oper block bug where ip masks in oper::from::userhost did not always
-  work succesfully (ex: 192.168.* worked, but 192.168.*.* didn't). Issue was
+  work successfully (ex: 192.168.* worked, but 192.168.*.* didn't). Issue was
   introduced in 3.2.7, reported by tabrisnet (#0003494).
 - CGI:IRC + IPv6: Fixed cgiirc block hostname never matching ipv4 cgiirc
   gateway properly (..again..), this was previously reported by pv2b.

--- a/doc/Changes.older
+++ b/doc/Changes.older
@@ -2317,7 +2317,7 @@ seen. gmtime warning still there
   was never kicking in.
 - A few doc updates (example.conf).
 - Added EOS command (End Of Sync), which is sent between servers after a server has
-  succesfully synced (after introducing of channels, users, etc). This way we can
+  successfully synced (after introducing of channels, users, etc). This way we can
   easily distinct between linked servers and a connecting server.
   This is needed / very helpful for: snomask +F, new +f anti flood system, prolly
   other things as well. Services don't support this command, but it's not
@@ -3139,7 +3139,8 @@ seen. gmtime warning still there
 - Made major changes to +I (may need debugging)
   - When you set +I while on a chan it sends a PART to the rest of the channel
   - When you set -I which on a chan it sends a JOIN to the rest of the channel
-  - Net/TechAdmins now receive a JOIN/PART when you JOIN/PART a channel  - Net/TechAdmins can now see +I users in /names
+  - Net/TechAdmins now receive a JOIN/PART when you JOIN/PART a channel
+  - Net/TechAdmins can now see +I users in /names
 - Fixed a typo in s_err.c reported by TRON
 - Fixed more -Wall warnings
 - Added #define LIST_SHOW_MODES to show channel modes in a /list (NOTE: only shows modes, not params)
@@ -3471,7 +3472,8 @@ seen. gmtime warning still there
   more channels on connect, read networks/unrealircd.conf for more info
 - Added networks/axenet.network
 - Possible change in the -1 operator bug
-- /info changes- Unreal3.1-beta1 release
+- /info changes
+- Unreal3.1-beta1 release
 - Added a bunch of networks
 - Updated doc/conf.doc
 - Updated networks/networks.ndx cause someone *cough* sts *cough* forgot

--- a/src/modules/m_watch.c
+++ b/src/modules/m_watch.c
@@ -53,9 +53,9 @@ MOD_UNLOAD(m_watch)
 }
 
 /*
- * RPL_NOWON	- Online at the moment (Succesfully added to WATCH-list)
- * RPL_NOWOFF	- Offline at the moement (Succesfully added to WATCH-list)
- * RPL_WATCHOFF	- Succesfully removed from WATCH-list.
+ * RPL_NOWON	- Online at the moment (Successfully added to WATCH-list)
+ * RPL_NOWOFF	- Offline at the moement (Successfully added to WATCH-list)
+ * RPL_WATCHOFF	- Successfully removed from WATCH-list.
  * ERR_TOOMANYWATCH - Take a guess :>  Too many WATCH entries.
  */
 static void show_watch(aClient *cptr, char *name, int rpl1, int rpl2, int awaynotify)

--- a/src/timesynch.c
+++ b/src/timesynch.c
@@ -156,7 +156,7 @@ int n, addrlen, i, highestfd = 0;
 fd_set r;
 struct timeval tv;
 char buf[512], *buf_out;
-int succesfully_sent = 0;
+int successfully_sent = 0;
 
 	strlcpy(tmptimeservbuf, TIMESYNCH_SERVER, sizeof(tmptimeservbuf));
 
@@ -200,10 +200,10 @@ int succesfully_sent = 0;
 		if (n < 0)
 			ircd_log(LOG_ERROR, "TimeSync: WARNING: Was unable to send packet to server #%d... ", i);
 		else
-			succesfully_sent++;
+			successfully_sent++;
 	}
 
-	if (!succesfully_sent)
+	if (!successfully_sent)
 	{
 		ircd_log(LOG_ERROR, "TimeSync: WARNING: Unable to send time synchronization packets to ANY time server. "
 		                    "Perhaps your firewall is blocking outgoing packets to UDP port 123?");
@@ -255,7 +255,7 @@ int succesfully_sent = 0;
 					continue;
 				}
 
-				/* succes... check size */
+				/* success... check size */
 				if (n >= 48)
 				{
 					t = extracttime(buf);
@@ -274,9 +274,9 @@ gotit:
 	offset = t - now;
 
 	if ((offset >= -1) && (offset <= 1)) /* no offset (or only +1/-1) */
-		ircd_log(LOG_ERROR, "TIME SYNCH: IRCd clock succesfully synchronized to known good time source.");
+		ircd_log(LOG_ERROR, "TIME SYNCH: IRCd clock successfully synchronized to known good time source.");
 	else
-		ircd_log(LOG_ERROR, "TIME SYNCH: IRCd clock succesfully synchronized to known good time source [offset: %ld, was: %ld].",
+		ircd_log(LOG_ERROR, "TIME SYNCH: IRCd clock successfully synchronized to known good time source [offset: %ld, was: %ld].",
 			(long)offset, (long)TSoffset);
 	
 	TSoffset = offset;


### PR DESCRIPTION
Original patch by @theRoda. Closes #41.