### PR TITLE
Use localstatedir instead of datadir for tunefile, etc.

### DIFF
--- a/Config
+++ b/Config
@@ -72,7 +72,7 @@ ARG="$ARG--disable-prefixaq "
 fi
 
 ARG="$ARG--with-bindir=$BINDIR "
-ARG="$ARG--with-datadir=$DATADIR "
+ARG="$ARG--localstatedir=$DATADIR "
 ARG="$ARG--with-pidfile=$DATADIR/unrealircd.pid "
 ARG="$ARG--with-confdir=$CONFDIR "
 ARG="$ARG--with-modulesdir=$MODULESDIR "

--- a/Makefile.in
+++ b/Makefile.in
@@ -24,6 +24,12 @@ INCLUDEDIR=@UNRLINCDIR@
 NETWORKSDIR=
 FROMDOS=/home/cmunk/bin/4dos
 
+# Wouldn’t need all this if we just switched to automake…
+PACKAGE_NAME=@PACKAGE_NAME@
+prefix=@prefix@
+localstatedir=@localstatedir@
+pkglocalstatedir=@pkglocalstatedir@
+
 # [CHANGEME]
 # Default flags:
 # Change XCFLAGS if you don't like what Config puts there.  Same with
@@ -108,7 +114,8 @@ FD_SETSIZE=@FD_SETSIZE@
 # Where is your openssl binary
 OPENSSLPATH=@OPENSSLPATH@
 
-CFLAGS=-I$(INCLUDEDIR) $(XCFLAGS) @LDFLAGS@ $(FD_SETSIZE)
+CPPFLAGS=@CPPFLAGS@ -I$(INCLUDEDIR) $(FD_SETSIZE) -DPKGLOCALSTATEDIR='"${pkglocalstatedir}"'
+CFLAGS=$(XCFLAGS) $(CPPFLAGS) @LDFLAGS@
 
 SHELL=/bin/sh
 SUBDIRS=src
@@ -120,7 +127,7 @@ TOUCH=@TOUCH@
 RES=
 all:	build
 
-MAKEARGS =	'CFLAGS=${CFLAGS}' 'CC=${CC}' 'IRCDLIBS=${IRCDLIBS}' \
+MAKEARGS =	"CFLAGS=`for f in ${CFLAGS}; do echo -n \'$${f}\'\ ; done`" 'CC=${CC}' 'IRCDLIBS=${IRCDLIBS}' \
 		'LDFLAGS=${LDFLAGS}' 'IRCDMODE=${IRCDMODE}' \
 		'RES=${RES}' 'BINDIR=${BINDIR}' 'INSTALL=${INSTALL}' \
 		'INCLUDEDIR=${INCLUDEDIR}' \

--- a/configure.ac
+++ b/configure.ac
@@ -486,11 +486,13 @@ AC_ARG_WITH(tmpdir, [AS_HELP_STRING([--with-tmpdir=path],[Specify the directory 
 	[AC_DEFINE_UNQUOTED([TMPDIR], ["$HOME/unrealircd/tmp"], [Define the location of private temporary files])
 		TMPDIR="$HOME/unrealircd/tmp"])
 
-AC_ARG_WITH(datadir, [AS_HELP_STRING([--with-datadir=path],[Specify the directory where permanent data is stored])],
-	[AC_DEFINE_UNQUOTED([PERMDATADIR], ["$withval"], [Define the location of permanent data files])
-		PERMDATADIR="$withval"],
-	[AC_DEFINE_UNQUOTED([DATADIR], ["$HOME/unrealircd/data"], [Define the location of permanent data files])
-		PERMDATADIR="$HOME/unrealircd/data"])
+AC_ARG_WITH([standard-dirs], [AS_HELP_STRING([--with-standard-dirs], [Specify that common directory conventions used by autoconf and unix distributions be used.])],
+	[WITH_FHS="$withval"],
+	[WITH_FHS=no])
+AS_IF([test "x$WITH_FHS" = "xyes"],
+	[pkglocalstatedir='${localstatedir}/${PACKAGE_NAME}'],
+	[pkglocalstatedir='${localstatedir}'])
+AC_SUBST([pkglocalstatedir])
 
 AC_ARG_WITH(docdir, [AS_HELP_STRING([--with-docdir=path],[Specify the directory where documentation is stored])],
 	[AC_DEFINE_UNQUOTED([DOCDIR], ["$withval"], [Define the location of the documentation])

--- a/include/config.h
+++ b/include/config.h
@@ -243,7 +243,7 @@
 #define	LPATH		LOGDIR"/debug.log"	/* Where the debug file lives, if DEBUGMODE */
 #define VPATH		CONFDIR"/ircd.svsmotd"	/* Services MOTD append. */
 #define BPATH		CONFDIR"/bot.motd"	/* Bot MOTD */
-#define IRCDTUNE 	PERMDATADIR"/ircd.tune"	/* tuning .. */
+#define IRCDTUNE 	PKGLOCALSTATEDIR"/ircd.tune"	/* tuning .. */
 
 /* CHROOTDIR
  *

--- a/src/Makefile
+++ b/src/Makefile
@@ -33,14 +33,15 @@ OBJS=timesynch.o res.o s_bsd.o auth.o aln.o channel.o cloak.o crule.o dbuf.o \
 
 SRC=$(OBJS:%.o=%.c)
 
-MAKEARGS =	'CFLAGS=${CFLAGS}' 'CC=${CC}' 'IRCDLIBS=${IRCDLIBS}' \
+MAKEARGS =	"CFLAGS=`for f in ${CFLAGS}; do echo -n \'$${f}\'\ ; done`" 'CC=${CC}' 'IRCDLIBS=${IRCDLIBS}' \
 		'LDFLAGS=${LDFLAGS}' 'IRCDMODE=${IRCDMODE}' \
-		'BINDIR=${BINDIR}' 'INSTALL=${INSTALL}' \
+		'RES=${RES}' 'BINDIR=${BINDIR}' 'INSTALL=${INSTALL}' \
 		'INCLUDEDIR=${INCLUDEDIR}' \
-		'MANDIR=${MANDIR}' 'RM=${RM}' 'CP=${CP}' 'TOUCH=${TOUCH}' \
-		'RES=${RES}' 'SHELL=${SHELL}' 'STRTOUL=${STRTOUL}' \
+		'RM=${RM}' 'CP=${CP}' 'TOUCH=${TOUCH}' \
+		'SHELL=${SHELL}' 'STRTOUL=${STRTOUL}' \
 		'CRYPTOLIB=${CRYPTOLIB}' \
-		'CRYPTOINCLUDES=${CRYPTOINCLUDES}' 'URL=${URL}' \
+		'CRYPTOINCLUDES=${CRYPTOINCLUDES}' \
+		'URL=${URL}'
 
 MY_MAKE = $(MAKE) $(MAKEARGS)
 

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -3322,7 +3322,7 @@ int	_test_files(ConfigFile *conf, ConfigEntry *ce)
 					cep->ce_varlinenum, "files::pidfile");
 				continue;
 			}
-			convert_to_absolute_path(&cep->ce_vardata, PERMDATADIR);
+			convert_to_absolute_path(&cep->ce_vardata, PKGLOCALSTATEDIR);
 			errors += config_test_openfile(cep, O_WRONLY | O_CREAT, 0600, "files::pidfile", 1, 0);
 			has_pidfile = 1;
 		}
@@ -3335,7 +3335,7 @@ int	_test_files(ConfigFile *conf, ConfigEntry *ce)
 					cep->ce_varlinenum, "files::tunefile");
 				continue;
 			}
-			convert_to_absolute_path(&cep->ce_vardata, PERMDATADIR);
+			convert_to_absolute_path(&cep->ce_vardata, PKGLOCALSTATEDIR);
 			errors += config_test_openfile(cep, O_RDWR | O_CREAT, 0600, "files::tunefile", 1, 0);
 			has_tunefile = 1;
 		}


### PR DESCRIPTION
datadir is normally /usr/share and specifies the location of files
that are never modified. localstatedir is normally /var/lib and
where you are supposed to place files which should be modified.
This change moves slightly towards doing directories how one
should when using autoconf and uses the existing --localstatedir
option, removing the redundant and misused --with-datadir.

The change should be transparent to anyone using ./Config. I have
also added --with-standard-dirs which would give one directly
invoking ./configure and passing --localstatedir the results
they expect (if you passed --localstatedir=/var/lib you’d expect
unrealircd to store its state in /var/lib/unrealircd).
