### PR TITLE
Remove 'gay' from the bad words list.

### DIFF
--- a/doc/conf/badwords.conf
+++ b/doc/conf/badwords.conf
@@ -45,7 +45,6 @@ badword all { word "*fucker*"; };
 badword all { word "faggot"; };
 badword all { word "fag"; };
 badword all { word "horny"; };
-badword all { word "gay"; };
 badword all { word "dickhead"; };
 badword all { word "sonuvabitch"; };
 badword all { word "*fuck*"; };


### PR DESCRIPTION
Cause this was an embarrassingly archaic view a decade ago never mind in 2016.