### PR TITLE
Fix #0004826

### DIFF
--- a/unrealircd.in
+++ b/unrealircd.in
@@ -63,7 +63,9 @@ elif [ "$1" = "stop" ] ; then
 		exit 1
 	fi
 	sleep 1
-	kill -9 `cat $PID_FILE` 1>/dev/null 2>&1
+	if [ -r $PID_FILE ] ; then
+		kill -9 `cat $PID_FILE` 1>/dev/null 2>&1
+	fi
 elif [ "$1" = "rehash" ] ; then
 	echo "Rehashing UnrealIRCd"
 	if [ ! -r $PID_FILE ] ; then


### PR DESCRIPTION
Fixes #0004826: ./unrealircd stop always says unrealircd.pid: No such file

https://bugs.unrealircd.org/view.php?id=4826