### PR TITLE
Update operclass.default.conf

### DIFF
--- a/doc/conf/operclass.default.conf
+++ b/doc/conf/operclass.default.conf
@@ -115,7 +115,7 @@ operclass netadmin {
 		immune;
 		notice;
 		self;
-		server { opermotd; info; close; remote; module; dns; addline; rehash; description; addmotd; addomotd; tsctl; };
+		server { opermotd; info; close; remote; module; dns; addline; rehash; description; addmotd; addomotd; tsctl; restart; die; };
 		kill;
 		tkl { shun; zline; kline; gline; };
 		route;


### PR DESCRIPTION
IMHO, I think that `restart` and `die` privileges should be enabled by default to network administrators. This fix aims to correct that.
If, however, you feel that things should be kept as is, feel free to ignore this PR.

Cheers,
The_Myth