### PR TITLE
m_message: Also strip monospace/strikethrough

### DIFF
--- a/src/modules/m_message.c
+++ b/src/modules/m_message.c
@@ -839,6 +839,12 @@ char *_StripControlCodes(unsigned char *text)
 			case 29:
 				/* italic */
 				break;
+			case 30:
+				/* strikethrough */
+				break;
+			case 17:
+				/* monospace */
+				break;
 			default:
 				new_str[i] = *text;
 				i++;


### PR DESCRIPTION
## In short

* Add ASCII for strikethrough (`0x1E`, `30`) and monospace (`0x11`, `17`) to `_StripControlCodes` function
  * Fixes those formatting characters not being filtered when `nocodes` module is loaded
  * Based on the [IRC Formatting documentation](https://modern.ircdocs.horse/formatting.html#characters ) and implementation in IRC clients

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Addresses rarely-used formatting codes not being filtered
Risk | ★☆☆ *1/3* | Might filter more than intended
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Testing
### Steps

1. Set up UnrealIRCd
2. Load the `nocodes` module
3. Connect with a monospace/strikethrough-capable client, join `#test`
   * *Many options available, including [Quassel IRC](https://quassel-irc.org/ )*
4. Connect another monospace/strikethrough-capable client, join `#test`
   * *Also used [Quasseldroid](https://quasseldroid.info/ ), since Quassel desktop currently only supports displaying*
5. Send a message with monospace/strikethrough formatting
6. Set channel mode `+S`
7. Send another message with monospace/strikethrough formatting

### Before

Formatting characters get through regardless of `+S`.

### After

![Screenshot of Quassel IRC showing behavior of the #test channel with strip colors on and off](https://zorro.casa/sync/Hosting/Utilities/Development/UnrealIRCd/pr/fix-strip-monostrike-format/After%20-%20nocodes%20strip%20for%20monospace%20and%20strikethrough.png#v1 )

> --> dcircuit_observe (quassel@Clk-72C7A769) has joined #test
> *** Mode #test + by irc.foonet.com
> \* Channel #test created on 2018-09-15 21:14:16 UTC
> \<@digitalcircuit\> Test `monospace`, **strike through** with strip off
> *** Mode #test +S by digitalcircuit
> \<@digitalcircuit\> Test monospace, strike through with strip on

*In the above, I've simulated strikethrough in Markdown using bold.*