### PR TITLE
Update example.conf

### DIFF
--- a/doc/conf/examples/example.conf
+++ b/doc/conf/examples/example.conf
@@ -409,9 +409,14 @@ set {
 	modes-on-connect "+ixw"; /* when users connect, they will get these user modes */
 	modes-on-oper	 "+xwgs"; /* when someone becomes IRCOp they'll get these modes */
 	oper-auto-join "#opers"; /* IRCOps are auto-joined to this channel */
+	modes-on-join "+nt"; /* This defaults helps usersto prevent their channel from being spammed from outsiders */
+	restrict-usermodes "x"; /* Prevents users from disabling the default cloaking and therefore exposing their real IP address */
+	allow-userhost-change "force-rejoin"; /* The default 'always' can cause client desyncs */
+	cloak-method ip; /* Cloaks user always based on IP (XXX.YYY.ZZZ.IP style) without disabling DNS resolving */
 	options {
 		hide-ulines; /* hide U-lines in /MAP and /LINKS */
 		show-connect-info; /* show "looking up your hostname" messages on connect */
+		identd-check; /* Identd server will be checked for every connecting user. If fails, prefixes ident with an ~. Usefull for some public services such as ZNC */
 	};
 
 	maxchannelsperuser 10; /* maximum number of channels a user may /JOIN */


### PR DESCRIPTION
Added `set::modes-on-join "+nt"` to the current configuration to help users to keep their channel with sane defaults, when joining a non registered channel
Added `set::restrict-usermodes "x"` as being able to disable the default cloaking is a security risk
Changed `set::allow-userhost-change` to `force-rejoin` since the default `always` may lead to clients desynch
Added `set::cloak-method ip` since that way whe can still have the XXX.YYY.ZZZ.IP cloak without the need to disable DNS resolving
Added `set::options::identd-check` since it barely interfere with user connection and is helpful for public services that are properly configured, such as ZNC

That's all for now xD

Regards,
PeGaSuS