### PR TITLE
Enhance Windows Security: Changes to unrealsvc.c and gui.c which make it possible to run Unreal…

### DIFF
--- a/src/win32/gui.c
+++ b/src/win32/gui.c
@@ -218,8 +218,8 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	GetOSName(OSName);
 	if (VerInfo.dwPlatformId == VER_PLATFORM_WIN32_NT) 
 	{
-		SC_HANDLE hService, hSCManager = OpenSCManager(NULL, NULL, GENERIC_EXECUTE);
-		if ((hService = OpenService(hSCManager, "UnrealIRCd", GENERIC_EXECUTE))) 
+		SC_HANDLE hService, hSCManager = OpenSCManager(NULL, NULL, SC_MANAGER_CONNECT);
+		if ((hService = OpenService(hSCManager, "UnrealIRCd", SC_MANAGER_CONNECT))) 
 		{
 			int save_err = 0;
 			StartServiceCtrlDispatcher(DispatchTable); 

--- a/src/win32/unrealsvc.c
+++ b/src/win32/unrealsvc.c
@@ -66,9 +66,9 @@ int main(int argc, char *argv[]) {
 		strcpy(binpath,path);
 		strcat(binpath, "\\UnrealIRCd.exe");
 		hService = CreateService(hSCManager, "UnrealIRCd", "UnrealIRCd",
-				 SERVICE_ALL_ACCESS, SERVICE_WIN32_OWN_PROCESS,
+				 SERVICE_CHANGE_CONFIG, SERVICE_WIN32_OWN_PROCESS,
 				 SERVICE_AUTO_START, SERVICE_ERROR_NORMAL, binpath,
-				 NULL, NULL, NULL, NULL, NULL); 
+				 NULL, NULL, NULL, TEXT("NT AUTHORITY\\NetworkService"), ""); 
 		if (hService) 
 		{
 			printf("UnrealIRCd NT Service successfully installed");


### PR DESCRIPTION
**Makes it possible to run UnrealIRCd as a service on Windows with non-admin permissions, in line with the official documentation which recommends Linux users [NOT run as Root](https://www.unrealircd.org/docs/Do_not_run_as_root).** 

**unrealsvc.c**
•	Adjusted service access level from `SERVICE_ALL_ACCESS` to `SERVICE_CHANGE_CONFIG`
•	Adjusted the account to log on as to `“NT AUTHORITY\\NetworkService”`
**gui.c**
•	Adjusted the access level to the service control manager from `GENERIC_EXECUTE` to `SC_MANAGER_CONNECT`


Expands on the solution where another user [encountered this problem in the past](https://forums.unrealircd.org/viewtopic.php?t=3476). Now no workarounds or 'heinously complex' permissions would be needed, it's simply runs as Network Service.