### PR TITLE
Fix an incorrect /ELINE example bantype

### DIFF
--- a/src/modules/tkl.c
+++ b/src/modules/tkl.c
@@ -1463,7 +1463,7 @@ void eline_syntax(Client *client)
 	sendnotice(client, "8: Bypass antimixedutf8 module");
 	sendnotice(client, "v: Bypass ban version { } blocks");
 	sendnotice(client, "Examples:");
-	sendnotice(client, "/ELINE *@unrealircd.org kgf 0 This user is exempt");
+	sendnotice(client, "/ELINE *@unrealircd.org kGf 0 This user is exempt");
 	sendnotice(client, "/ELINE ~S:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef kgf 0 Trusted user with this certificate fingerprint");
 	sendnotice(client, "-");
 	sendnotice(client, "To get a list of all current ELINEs, type: /STATS except");


### PR DESCRIPTION
It should be 'G' instead of 'g' in the /ELINE example