### PR TITLE
Removing duplicate line in conf prog header

### DIFF
--- a/doc/Config.header
+++ b/doc/Config.header
@@ -11,7 +11,6 @@
                                     
 This program will help you to compile your IRC server, and ask you
 questions regarding the compile-time settings of it during the process. 
-regarding the setup of it, during the process.
 
 A short installation guide is available online at:
 https://www.unrealircd.org/docs/Installing_from_source


### PR DESCRIPTION
Noticed this duplicate line printed in the configuration program header while building and installing from source for the first time today.  It appears when you run the ```./Config``` [build step](https://www.unrealircd.org/docs/Installing_from_source#Compiling).  I know it's very small, but thought I'd submit a PR anyway since it's quite user-facing.