### PR TITLE
Fix trailing space in RPL_NAMREPLY

### DIFF
--- a/src/modules/names.c
+++ b/src/modules/names.c
@@ -183,7 +183,8 @@ CMD_FUNC(cmd_names)
 		 */
 		for (; *s; s++)
 			buf[idx++] = *s;
-		buf[idx++] = ' ';
+		if (cm->next)
+			buf[idx++] = ' ';
 		buf[idx] = '\0';
 		flag = 1;
 		if (mlen + idx + bufLen > BUFSIZE - 7)


### PR DESCRIPTION
Currently, UnrealIRCd outputs a trailing space to the trailing parameter of RPL_NAMREPLY (when there are users in the channel). However, according to RFC 1459 and RFC 2812, this is forbidden, since the grammar for this reply is (quoting RFC 2812):
```
( "=" / "*" / "@" ) <channel> :[ "@" / "+" ] <nick> *( " " [ "@" / "+" ] <nick> )
```

This commit fixes the issue by adding the joining space only if there is another, remaining nick to be appended to the buffer.