### PR TITLE
Add clienttagdeny module.

### DIFF
--- a/Makefile.windows
+++ b/Makefile.windows
@@ -292,7 +292,8 @@ DLL_FILES=SRC/MODULES/CLOAK.DLL \
  SRC/MODULES/IDENT_LOOKUP.DLL \
  SRC/MODULES/HISTORY.DLL \
  SRC/MODULES/TARGETFLOODPROT.DLL \
- SRC/MODULES/TYPING-INDICATOR.DLL
+ SRC/MODULES/TYPING-INDICATOR.DLL \
+ SRC/MODULES/CLIENTTAGDENY.DLL
 
 
 ALL: CONF UNREALSVC.EXE UnrealIRCd.exe MODULES 
@@ -1088,5 +1089,8 @@ src/modules/targetfloodprot.dll: src/modules/targetfloodprot.c $(INCLUDES)
 
 src/modules/typing-indicator.dll: src/modules/typing-indicator.c $(INCLUDES)
 	$(CC) $(MODCFLAGS) /Fosrc/modules/ /Fesrc/modules/ src/modules/typing-indicator.c $(MODLFLAGS)
+
+src/modules/clienttagdeny.dll: src/modules/clienttagdeny.c $(INCLUDES)
+	$(CC) $(MODCFLAGS) /Fosrc/modules /Fesrc/modules src/modules/clienttagdeny.c $(MODLFLAGS)
 
 dummy:

--- a/doc/conf/modules.default.conf
+++ b/doc/conf/modules.default.conf
@@ -208,6 +208,7 @@ loadmodule "sts"; /* strict transport policy (set::tls::sts-policy) */
 loadmodule "echo-message"; /* shows clients if their messages are altered/filtered */
 loadmodule "labeled-response"; /* correlate requests and responses easily */
 loadmodule "typing-indicator"; /* typing indicator in PM and channels (+draft/typing) */
+loadmodule "clienttagdeny"; /* informs clients about supported client-only message tags */
 
 
 /*** Other ***/

--- a/src/modules/Makefile.in
+++ b/src/modules/Makefile.in
@@ -73,7 +73,7 @@ R_MODULES= \
 	echo-message.so userip-tag.so userhost-tag.so \
 	typing-indicator.so \
 	ident_lookup.so history.so \
-	targetfloodprot.so
+	targetfloodprot.so clienttagdeny.so
 
 MODULES=cloak.so $(R_MODULES)
 MODULEFLAGS=@MODULEFLAGS@
@@ -635,6 +635,10 @@ history.so: history.c $(INCLUDES)
 targetfloodprot.so: targetfloodprot.c $(INCLUDES)
 	$(CC) $(CFLAGS) $(MODULEFLAGS) -DDYNAMIC_LINKING \
 		-o targetfloodprot.so targetfloodprot.c
+
+clienttagdeny.so: clienttagdeny.c $(INCLUDES)
+	$(CC) $(CFLAGS) $(MODULEFLAGS) -DDYNAMIC_LINKING \
+		-o clienttagdeny.so clienttagdeny.c
 
 #############################################################################
 # capabilities

--- a/src/modules/clienttagdeny.c
+++ b/src/modules/clienttagdeny.c
@@ -1,0 +1,78 @@
+/*
+ *   IRC - Internet Relay Chat, src/modules/echo-message.c
+ *   (C) 2020 k4be for The UnrealIRCd Team
+ *
+ *   See file AUTHORS in IRC package for additional names of
+ *   the programmers.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 1, or (at your option)
+ *   any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "unrealircd.h"
+
+char *ct_isupport_param(void);
+int tags_rehash_complete(void);
+
+extern MODVAR MessageTagHandler *mtaghandlers;
+Module *module;
+
+ModuleHeader MOD_HEADER = {
+	"clienttagdeny",
+	"5.0",
+	"Informs clients about supported client tags",
+	"k4be",
+	"unrealircd-5",
+};
+
+MOD_INIT(){
+	MARK_AS_OFFICIAL_MODULE(modinfo);
+
+	return MOD_SUCCESS;
+}
+
+MOD_LOAD(){
+	module = modinfo->handle;
+	ISupportAdd(module, "CLIENTTAGDENY", ct_isupport_param());
+	HookAdd(module, HOOKTYPE_REHASH_COMPLETE, 0, tags_rehash_complete);
+
+	return MOD_SUCCESS;
+}
+
+MOD_UNLOAD(){
+	return MOD_SUCCESS;
+}
+
+#define BUFLEN 500
+
+char *ct_isupport_param(void){
+	static char buf[BUFLEN];
+	MessageTagHandler *m;
+	
+	strlcpy(buf, "*", sizeof(buf));
+
+	for (m = mtaghandlers; m; m = m->next) {
+		if(!m->unloaded && m->name[0] == '+'){
+			strlcat(buf, ",-", sizeof(buf));
+			strlcat(buf, m->name+1, sizeof(buf));
+		}
+	}
+	return buf;
+}
+
+int tags_rehash_complete(void){
+	ISupportSet(module, "CLIENTTAGDENY", ct_isupport_param());
+	return HOOK_CONTINUE;
+}
+


### PR DESCRIPTION
It implements the current version of CLIENTTAGDENY isupport token, as defined by IRCv3 (not merged yet).