### PR TITLE
Fix to display the TLSversion correct on connect

### DIFF
--- a/src/send.c
+++ b/src/send.c
@@ -993,7 +993,7 @@ void sendto_connectnotice(Client *newuser, int disconnect, char *comment)
 
 		*secure = '\0';
 		if (IsSecure(newuser))
-			snprintf(secure, sizeof(secure), " [secure %s]", SSL_get_cipher(newuser->local->ssl));
+			snprintf(secure, sizeof(secure), " [secure %s]", tls_get_cipher(newuser->local->ssl));
 
 		ircsnprintf(connect, sizeof(connect),
 		    "*** Client connecting: %s (%s@%s) [%s] {%s}%s", newuser->name,


### PR DESCRIPTION
Previously it didn't display correctly on server notice the TLSv* version on local connection.

Example:

**TLS_CHACHA20_POLY1305_SHA256**

Should be displayed as: **TLSv1.3-TLS_CHACHA20_POLY1305_SHA256**