### PR TITLE
Add ciphers value on RPL_WHOISSECURE (671) locally

### DIFF
--- a/src/modules/whois.c
+++ b/src/modules/whois.c
@@ -314,7 +314,7 @@ CMD_FUNC(cmd_whois)
                                 if (MyUser(target))
                                         sendnumericfmt(client, RPL_WHOISSECURE,
                                                 "%s :is using a Secure Connection (%s)", target->name,
-                                                tls_get_cipher(target->local-ssl));
+                                                tls_get_cipher(target->local->ssl));
                                 else
                                         sendnumeric(client, RPL_WHOISSECURE, name,
                                                 "is using a Secure Connection");

--- a/src/modules/whois.c
+++ b/src/modules/whois.c
@@ -310,8 +310,15 @@ CMD_FUNC(cmd_whois)
 			}
 
 			if (target->umodes & UMODE_SECURE)
-				sendnumeric(client, RPL_WHOISSECURE, name,
-					"is using a Secure Connection");
+                        {
+                                if (MyUser(target))
+                                        sendnumericfmt(client, RPL_WHOISSECURE,
+                                                "%s :is using a Secure Connection (%s)", target->name,
+                                                tls_get_cipher(target->local-ssl));
+                                else
+                                        sendnumeric(client, RPL_WHOISSECURE, name,
+                                                "is using a Secure Connection");
+                        }
 			
 			RunHook2(HOOKTYPE_WHOIS, client, target);
 


### PR DESCRIPTION
If someone want's to view the TLS version + ciphers from a local client SSL connection he would now by WHOIS the user, this only will work for local clients and not for remote clients.

If this is security privacy risk addition then do not proceed of course.

Credits to **Jobe** who created the code.

- Thanks!