### PR TITLE
Bypass +H chanmode on BOTS (+B)

### DIFF
--- a/src/modules/chanmodes/history.c
+++ b/src/modules/chanmodes/history.c
@@ -534,7 +534,8 @@ int history_join(Client *client, Channel *channel, MessageTag *mtags, char *parv
 	if (!HistoryEnabled(channel))
 		return 0;
 
-	if (MyUser(client))
+	/* Check also if the client is a bot (+B) */
+	if (MyUser(client) && !IsBot(client))
 	{
 		HistoryFilter filter;
 		memset(&filter, 0, sizeof(filter));


### PR DESCRIPTION
I believe that when a bot joins in the channel and +H channel mode exists it should bypass it because it is useless to having history on join for bots, one issue can be if there was some bot commands executed before the bot join (e.g: !website) then when the bot joins it re-triggers that event.

Also bots can use `/HISTORY` command anytime if they want to view the channel history.