### PR TITLE
Fix when +f to not kick if is already banned

### DIFF
--- a/src/modules/chanmodes/floodprot.c
+++ b/src/modules/chanmodes/floodprot.c
@@ -955,6 +955,9 @@ int floodprot_can_send_to_channel(Client *client, Channel *channel, Membership *
 
 	if (sendtype == SEND_TYPE_TAGMSG)
 		return 0; // TODO: some TAGMSG specific limit? (1 of 2)
+	
+	if (is_banned(client, channel, BANCHK_MSG, NULL, NULL))
+		return HOOK_CONTINUE;
 
 	if (ValidatePermissionsForPath("channel:override:flood",client,NULL,channel,NULL) || !IsFloodLimit(channel) || is_skochanop(client, channel))
 		return HOOK_CONTINUE;


### PR DESCRIPTION
Currently when someone is banned or muted (~q extban) then if he keeps flooding on the channel then the +f triggers this action and kick the user away from the channel, as it should not and should only appear an error message that he cannot send to the channel because he is banned.

Example Image: 

![image](https://i.imgur.com/6moG1s6.png)

(Not sure if this change is correct, but i gave a try :P)

- Thanks!