### PR TITLE
Exit with a successful return code upon receipt of SIGTERM

### DIFF
--- a/src/ircd.c
+++ b/src/ircd.c
@@ -96,7 +96,7 @@ void s_die()
 #else
 	unload_all_modules();
 	unlink(conf_files ? conf_files->pid_file : IRCD_PIDFILE);
-	exit(-1);
+	exit(0);
 #endif
 }
 


### PR DESCRIPTION
Return code 255 (like any non-zero return code) indicates a failure on POSIX systems. Actually systemd.unit gets upset about this wrong exit code when stopping unrealircd.service systemd unit.