### PR TITLE
Fixed typo on the example flags, from `f` to `F` (spamfilter)

### DIFF
--- a/doc/conf/help/help.conf
+++ b/doc/conf/help/help.conf
@@ -952,7 +952,7 @@ help Eline {
 	" K-Lines, G-Lines and other types of bans.";
 	" Syntax:  ELINE <user@host> <bantypes> <expire-time> <reason> (Adds an E-Line)";
 	"          ELINE -<user@host>                               (Removes an E-Line)";
-	" Example: ELINE *@unrealircd.org kGf 0 This user is exempt";
+	" Example: ELINE *@unrealircd.org kGF 0 This user is exempt";
 	" Valid <bantypes> are:";
 	" ==-Type--------Name---------------------------Explanation-----------------------==";
 	"     k   |     K-Line    | Bypass K-Lines                                          ";

--- a/src/modules/tkl.c
+++ b/src/modules/tkl.c
@@ -1533,8 +1533,8 @@ void eline_syntax(Client *client)
 	sendnotice(client, "8: Bypass antimixedutf8 module");
 	sendnotice(client, "v: Bypass ban version { } blocks");
 	sendnotice(client, "Examples:");
-	sendnotice(client, "/ELINE *@unrealircd.org kGf 0 This user is exempt");
-	sendnotice(client, "/ELINE ~S:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef kGf 0 Trusted user with this certificate fingerprint");
+	sendnotice(client, "/ELINE *@unrealircd.org kGF 0 This user is exempt");
+	sendnotice(client, "/ELINE ~S:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef kGF 0 Trusted user with this certificate fingerprint");
 	sendnotice(client, "-");
 	sendnotice(client, "To get a list of all current ELINEs, type: /STATS except");
 }


### PR DESCRIPTION
Actually we don't have the `f` flag but `F` for spamfilter.