### PR TITLE
Allowing multiple masks in "deny link" blocks.

### DIFF
--- a/include/h.h
+++ b/include/h.h
@@ -862,6 +862,7 @@ extern int mixed_network(void);
 extern void unreal_delete_masks(ConfigItem_mask *m);
 extern void unreal_add_masks(ConfigItem_mask **head, ConfigEntry *ce);
 extern int unreal_mask_match(Client *acptr, ConfigItem_mask *m);
+extern int unreal_mask_match_string(const char *name, ConfigItem_mask *m);
 extern char *our_strcasestr(char *haystack, char *needle);
 extern void update_conf(void);
 extern MODVAR int need_34_upgrade;

--- a/include/struct.h
+++ b/include/struct.h
@@ -1734,7 +1734,8 @@ struct ConfigItem_deny_dcc {
 struct ConfigItem_deny_link {
 	ConfigItem_deny_link *prev, *next;
 	ConfigFlag_except flag;
-	char *mask, *rule, *prettyrule;
+	ConfigItem_mask  *mask;
+	char *rule, *prettyrule;
 };
 
 struct ConfigItem_deny_version {

--- a/src/ircd.c
+++ b/src/ircd.c
@@ -306,7 +306,7 @@ EVENT(try_connections)
 
 		/* Check connect rules to see if we're allowed to try the link */
 		for (deny = conf_deny_link; deny; deny = deny->next)
-			if (match_simple(deny->mask, aconf->servername) && crule_eval(deny->rule))
+			if (unreal_mask_match_string(aconf->servername, deny->mask) && crule_eval(deny->rule))
 				break;
 
 		if (!deny && connect_server(aconf, NULL, NULL) == 0)

--- a/src/misc.c
+++ b/src/misc.c
@@ -1166,6 +1166,25 @@ int unreal_mask_match(Client *client, ConfigItem_mask *m)
 	return 0;
 }
 
+/** Check if a string matches any of the masks in the mask list */
+int unreal_mask_match_string(const char *name, ConfigItem_mask *m)
+{
+	for (; m; m = m->next)
+	{
+		/* With special support for '!' prefix (negative matching like "!192.168.*") */
+		if (m->mask[0] == '!')
+		{
+			if (!match_simple(m->mask+1, name))
+				return 1;
+		} else {
+			if (match_simple(m->mask+1, name))
+				return 1;
+		}
+	}
+
+	return 0;
+}
+
 /** Our own strcasestr implementation because strcasestr is
  * often not available or is not working correctly.
  */

--- a/src/modules/connect.c
+++ b/src/modules/connect.c
@@ -117,7 +117,7 @@ CMD_FUNC(cmd_connect)
 	/* Evaluate deny link */
 	for (deny = conf_deny_link; deny; deny = deny->next)
 	{
-		if (deny->flag.type == CRULE_ALL && match_simple(deny->mask, aconf->servername)
+		if (deny->flag.type == CRULE_ALL && unreal_mask_match_string(aconf->servername, deny->mask)
 			&& crule_eval(deny->rule))
 		{
 			sendnotice(client, "*** Connect: Disallowed by connection rule");

--- a/src/modules/server.c
+++ b/src/modules/server.c
@@ -597,7 +597,7 @@ CMD_FUNC(cmd_server)
 	/* Process deny server { } restrictions */
 	for (deny = conf_deny_link; deny; deny = deny->next)
 	{
-		if (deny->flag.type == CRULE_ALL && match_simple(deny->mask, servername)
+		if (deny->flag.type == CRULE_ALL && unreal_mask_match_string(servername, deny->mask)
 			&& crule_eval(deny->rule))
 		{
 			sendto_ops_and_log("Refused connection from %s. Rejected by deny link { } block.",


### PR DESCRIPTION
The goal of this patch is allowing the following syntax for `deny link` blocks:


```
deny link {
	mask {
		*;
		!foobar.hub;
	};
	rule !connected(foobar.hub);
	type all;
};
```

to prevent the current server from accepting connections from other leaf servers while the server is separated to the network (to prevent leaves with multiple autoconnects from bridging between two hubs)