### PR TITLE
Fix mask matching for `deny link::mask` blocks

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -1166,7 +1166,9 @@ int unreal_mask_match(Client *client, ConfigItem_mask *m)
 	return 0;
 }
 
-/** Check if a string matches any of the masks in the mask list */
+/** Check if a string matches any of the masks in the mask list.
+ * Returns 1 if no masks match the string
+ */
 int unreal_mask_match_string(const char *name, ConfigItem_mask *m)
 {
 	for (; m; m = m->next)
@@ -1174,15 +1176,15 @@ int unreal_mask_match_string(const char *name, ConfigItem_mask *m)
 		/* With special support for '!' prefix (negative matching like "!192.168.*") */
 		if (m->mask[0] == '!')
 		{
-			if (!match_simple(m->mask+1, name))
-				return 1;
-		} else {
 			if (match_simple(m->mask+1, name))
-				return 1;
+				return 0;
+		} else {
+			if (!match_simple(m->mask+1, name))
+				return 0;
 		}
 	}
 
-	return 0;
+	return 1;
 }
 
 /** Our own strcasestr implementation because strcasestr is


### PR DESCRIPTION
Small slip up from my previous PR.

For our use-case of `deny link::mask` it really makes more sense to deny linking when *no masks* match.

Take this block for example:

```
deny link {
	mask {
		!foobar.hub;
                !somethingelse.hub;
	};
	rule !connected(foobar.hub)&&!connected(somethingelse.hub);
	type all;
};
```

would end up denying all links because you can't match `foobar.hub` and `somethingelse.hub` at the same time. This is fixed by having the function return 0 on the first non-match