### PR TITLE
Don't handle certfp in 'MD client'

### DIFF
--- a/src/modules/md.c
+++ b/src/modules/md.c
@@ -101,6 +101,10 @@ CMD_FUNC(cmd_md)
 
 	if (!strcmp(type, "client"))
 	{
+		// dont allow certfp spoofing
+		if (!strcmp(varname, "certfp"))
+			return;
+
 		Client *target = find_client(objname, NULL);
 		md = findmoddata_byname(varname, MODDATATYPE_CLIENT);
 		if (!md || !md->unserialize || !target)


### PR DESCRIPTION
certfp may be used in oper{} blocks and sasl, allowing other
servers to spoof it makes certfp useless for auth.
