### PR TITLE
Designate end of HELP(OP) output

### DIFF
--- a/src/modules/help.c
+++ b/src/modules/help.c
@@ -56,6 +56,7 @@ MOD_UNLOAD()
 
 #define HDR(str) sendto_one(client, NULL, ":%s 290 %s :%s", me.name, client->name, str);
 #define SND(str) sendto_one(client, NULL, ":%s 292 %s :%s", me.name, client->name, str);
+#define HND(str) sendto_one(client, NULL, ":%s 292 %s :%s", me.name, client->name, str);
 
 ConfigItem_help *find_Help(char *command)
 {
@@ -97,7 +98,7 @@ void parse_help(Client *client, char *name, char *help)
 			SND(text->line);
 			text = text->next;
 		}
-		SND(" -");
+		HND(" -");
 		return;
 		
 	}
@@ -110,7 +111,7 @@ void parse_help(Client *client, char *name, char *help)
 		SND(" -");
 		sendto_one(client, NULL, ":%s 292 %s : ***** Go to %s if you have any further questions *****",
 		    me.name, client->name, helpchan);
-		SND(" -");
+		HND(" -");
 		return;
 	}
 	text = helpitem->text;
@@ -122,7 +123,7 @@ void parse_help(Client *client, char *name, char *help)
 		SND(text->line);
 		text = text->next;
 	}
-	SND(" -");
+	HND(" -");
 }
 
 /*

--- a/src/modules/help.c
+++ b/src/modules/help.c
@@ -56,7 +56,7 @@ MOD_UNLOAD()
 
 #define HDR(str) sendto_one(client, NULL, ":%s 290 %s :%s", me.name, client->name, str);
 #define SND(str) sendto_one(client, NULL, ":%s 292 %s :%s", me.name, client->name, str);
-#define HND(str) sendto_one(client, NULL, ":%s 292 %s :%s", me.name, client->name, str);
+#define HND(str) sendto_one(client, NULL, ":%s 293 %s :%s", me.name, client->name, str);
 
 ConfigItem_help *find_Help(char *command)
 {

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -319,10 +319,10 @@ static char *replies[] = {
 /* 287 */ NULL, /* aircd, quakenet */
 /* 288 */ NULL, /* aircd, quakenet */
 /* 289 */ NULL, /* aircd, quakenet */
-/* 290	HELP(OP) header */ NULL, /* aircd, quakenet */ 
+/* 290	RPL_HELPHDR */ NULL, /* aircd, quakenet */ 
 /* 291 */ NULL, /* aircd, quakenet */
-/* 292	HELP(OP) attached info */ NULL, /* aircd */
-/* 293	HELP(OP) end of attached info */ NULL, /* aircd */
+/* 292	RPL_HELPTLR */ NULL, /* aircd */
+/* 293	RPL_HELPHLP */ NULL, /* aircd */
 /* 294    RPL_HELPFWD */ ":Your help-request has been forwarded to Help Operators",
 /* 295    RPL_HELPIGN */ ":Your address has been ignored from forwarding",
 /* 296 */ NULL, /* aircd */

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -319,10 +319,10 @@ static char *replies[] = {
 /* 287 */ NULL, /* aircd, quakenet */
 /* 288 */ NULL, /* aircd, quakenet */
 /* 289 */ NULL, /* aircd, quakenet */
-/* 290 */ NULL, /* aircd, quakenet */
+/* 290	HELP(OP) header */ NULL, /* aircd, quakenet */ 
 /* 291 */ NULL, /* aircd, quakenet */
-/* 292 */ NULL, /* aircd */
-/* 293 */ NULL, /* aircd */
+/* 292	HELP(OP) attached info */ NULL, /* aircd */
+/* 293	HELP(OP) end of attached info */ NULL, /* aircd */
 /* 294    RPL_HELPFWD */ ":Your help-request has been forwarded to Help Operators",
 /* 295    RPL_HELPIGN */ ":Your address has been ignored from forwarding",
 /* 296 */ NULL, /* aircd */


### PR DESCRIPTION
repurpose unused numeric response RPL_HELPHLP to signify end of output for use cases such like client-side scriptables (viewing) and in case a bot gains self-awareness :> ♥