### PR TITLE
Allow remote servers to write to the `link-security` MD object

### DIFF
--- a/src/modules/link-security.c
+++ b/src/modules/link-security.c
@@ -59,6 +59,7 @@ MOD_INIT()
 	mreq.serialize = link_security_md_serialize;
 	mreq.unserialize = link_security_md_unserialize;
 	mreq.sync = 1;
+	mreq.remote_write = 1;
 	link_security_md = ModDataAdd(modinfo->handle, mreq);
 	if (!link_security_md)
 	{


### PR DESCRIPTION
Should fix the warning @stefansaraev found