### PR TITLE
Fix for mod data client modification restriction inconsistency

### DIFF
--- a/src/modules/md.c
+++ b/src/modules/md.c
@@ -106,7 +106,7 @@ CMD_FUNC(cmd_md)
 		if (!md || !md->unserialize || !target)
 			return;
 
-		if (MyConnect(target) && !md->remote_write)
+		if ((target->srvptr != client) && (target != client) && !md->remote_write)
 		{
 			ircd_log(LOG_ERROR, "Remote server '%s' tried to write moddata '%s' of a client from ours '%s' -- attempt blocked.",
 			         client->name, md->name, target->name);


### PR DESCRIPTION
Allow a server to modify mod data for its own clients and itself even if it is a client of the server receiving the MD message. This should fix bug https://bugs.unrealircd.org/view.php?id=5960