### PR TITLE
Sending WALLOPS back to the oper that issued it.

### DIFF
--- a/src/modules/wallops.c
+++ b/src/modules/wallops.c
@@ -73,5 +73,8 @@ CMD_FUNC(cmd_wallops)
 		return;
 	}
 
+	if (MyUser(client))
+		sendto_one(client, NULL, ":%s WALLOPS :%s", client->name, message);
+
 	sendto_ops_butone(client->direction, client, ":%s WALLOPS :%s", client->name, message);
 }


### PR DESCRIPTION
This reassures the oper that the message was actually sent, and
makes it consistent with the behavior of GLOBOPS and NOTICE $*