### PR TITLE
Return ERR_INVALIDMODEPARAM instead of truncating invalid keys

### DIFF
--- a/include/numeric.h
+++ b/include/numeric.h
@@ -371,6 +371,7 @@
 
 #define RPL_SPAMCMDFWD       659
 
+#define ERR_INVALIDMODEPARAM 696
 #define RPL_STARTTLS         670
 
 #define RPL_WHOISSECURE      671

--- a/src/modules/mode.c
+++ b/src/modules/mode.c
@@ -1033,7 +1033,7 @@ process_listmode:
 					if (error) {
 						if (MyUser(client))
 							sendnumeric(client, ERR_INVALIDMODEPARAM,
-								channel->chname, "k", "*", error);
+								channel->chname, modechar, "*", error);
 						break;
 					}
 					if (!strcmp(channel->mode.key, param))

--- a/src/modules/mode.c
+++ b/src/modules/mode.c
@@ -1023,18 +1023,21 @@ process_listmode:
 			{
 				if (!bounce) {	/* don't do the mode at all. */
 					char *tmp;
-					if ((tmp = strchr(param, ' ')))
-					*tmp = '\0';
-					if ((tmp = strchr(param, ':')))
-					*tmp = '\0';
-					if ((tmp = strchr(param, ',')))
-					*tmp = '\0';
+					char *error = NULL;
+					if (strchr(param, ' ') || strchr(param, ':') || strchr(param, ','))
+						error = "Invalid key mode parameter, invalid character(s).";
 					if (*param == '\0')
-					break;
+						error = "Invalid key mode parameter, it may not be empty.";
 					if (strlen(param) > KEYLEN)
-						param[KEYLEN] = '\0';
+						error = "Invalid key mode parameter, it is too long.";
+					if (error) {
+						if (MyUser(client))
+							sendnumeric(client, ERR_INVALIDMODEPARAM,
+								channel->chname, "k", "*", error);
+						break;
+					}
 					if (!strcmp(channel->mode.key, param))
-					break;
+						break;  /* no change */
 					strlcpy(channel->mode.key, param, sizeof(channel->mode.key));
 				}
 				tmpstr = param;

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -740,7 +740,7 @@ static char *replies[] = {
 /* 693 */ NULL,
 /* 694 */ NULL,
 /* 695 */ NULL,
-/* 696 */ NULL,
+/* 696 ERR_INVALIDMODEPARAM */ "%s %s %s :%s",
 /* 697 */ NULL,
 /* 698 */ NULL,
 /* 699 */ NULL,

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -740,7 +740,7 @@ static char *replies[] = {
 /* 693 */ NULL,
 /* 694 */ NULL,
 /* 695 */ NULL,
-/* 696 ERR_INVALIDMODEPARAM */ "%s %s %s :%s",
+/* 696 ERR_INVALIDMODEPARAM */ "%s %c %s :%s",
 /* 697 */ NULL,
 /* 698 */ NULL,
 /* 699 */ NULL,


### PR DESCRIPTION
This is more user-friendly (prevents setting a different key than
what the other requested) and makes the behavior consistent with
InspIRCd and Ergo (and hopefully others soon).

https://github.com/ircdocs/modern-irc/pull/111