### PR TITLE
Send RPL_WHOISACTUALLY in addition to RPL_WHOISHOST

### DIFF
--- a/include/numeric.h
+++ b/include/numeric.h
@@ -193,6 +193,7 @@
 
 #define RPL_INVITELIST       336
 #define RPL_ENDOFINVITELIST  337
+#define RPL_WHOISACTUALLY    338
 
 #define RPL_LISTSYNTAX       334
 #define RPL_WHOISBOT	     335

--- a/src/modules/whois.c
+++ b/src/modules/whois.c
@@ -136,6 +136,12 @@ CMD_FUNC(cmd_whois)
 			}
 			if ((target == client) || IsOper(client))
 			{
+				/* Clients should prefer RPL_WHOISACTUALLY as it is easier to parse,
+				 * but we provide RPL_WHOISHOST (despite it being redundant)
+				 * for backward compatibility */
+				sendnumeric(client, RPL_WHOISACTUALLY, target->name,
+					(MyConnect(target) && strcmp(target->ident, "unknown")) ? target->ident : "*",
+					target->user->realhost, target->ip ? target->ip : "");
 				sendnumeric(client, RPL_WHOISHOST, target->name,
 					(MyConnect(target) && strcmp(target->ident, "unknown")) ? target->ident : "*",
 					target->user->realhost, target->ip ? target->ip : "");

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -371,7 +371,7 @@ static char *replies[] = {
 /* 335    RPL_WHOISBOT */ "%s :is a \2Bot\2 on %s",
 /* 336    RPL_INVITELIST */ ":%s",
 /* 337    RPL_ENDOFINVITELIST */ ":End of /INVITE list.",
-/* 338 */ NULL, /* ircu, bahamut */
+/* 338    RPL_WHOISACTUALLY */ "%s %s@%s %s :is connecting from",
 /* 339 */ NULL, /* Used */
 /* 340    RPL_USERIP */ ":%s %s %s %s %s",
 /* 341    RPL_INVITING */ "%s %s",


### PR DESCRIPTION
Unlike RPL_WHOISHOST, it contains the user@host and ip as separate parameters,
instead of having them in the free-text parameter.

To my knowledge, there are three different syntaxes for RPL_WHOISACTUALLY:

1. `<client> <nick> :is actually ...` (bahamut)
2. `<client> <nick> <host> :Is actually using host` (charybdis family)
3. `<client> <nick> <username>@<host> <ip> :Is actually using host`
   (ircu2, ergo, hybrid, ...)

I chose the third one because it contains the most info, and is the most
common one.

I kept RPL_WHOISHOST despite being redundant for backward compatibility,
but I can remove it if you prefer.