### PR TITLE
Correct chgcmd snotice behaviour

### DIFF
--- a/src/modules/chghost.c
+++ b/src/modules/chghost.c
@@ -326,10 +326,10 @@ CMD_FUNC(cmd_chghost)
 	if (!IsULine(client))
 	{
 		unreal_log(ULOG_INFO, "chgcmds", "CHGHOST_COMMAND", client,
-		           "CHGHOST: $client changed the virtual hostname of $target.detail to be $new_hostname",
+		           "CHGHOST: $client changed the virtual hostname of $target to be $new_hostname",
 		           log_data_string("change_type", "hostname"),
-		           log_data_string("new_hostname", parv[2]),
-		           log_data_client("target", target));
+			   log_data_client("target", target)
+		           log_data_string("new_hostname", parv[2]));
 	}
 
 	target->umodes |= UMODE_HIDE;

--- a/src/modules/chghost.c
+++ b/src/modules/chghost.c
@@ -326,7 +326,7 @@ CMD_FUNC(cmd_chghost)
 	if (!IsULine(client))
 	{
 		unreal_log(ULOG_INFO, "chgcmds", "CHGHOST_COMMAND", client,
-		           "CHGHOST: $client changed the virtual hostname of $target to be $new_hostname",
+		           "CHGHOST: $client changed the virtual hostname of $target.details to be $new_hostname",
 		           log_data_string("change_type", "hostname"),
 			   log_data_client("target", target)
 		           log_data_string("new_hostname", parv[2]));

--- a/src/modules/chgident.c
+++ b/src/modules/chgident.c
@@ -135,10 +135,10 @@ CMD_FUNC(cmd_chgident)
 	if (!IsULine(client))
 	{
 		unreal_log(ULOG_INFO, "chgcmds", "CHGIDENT_COMMAND", client,
-		           "CHIDENT: $client changed the username of $target.detail to be $new_username",
+		           "CHIDENT: $client changed the username of $target to be $new_username",
 		           log_data_string("change_type", "username"),
-		           log_data_string("new_username", parv[2]),
-		           log_data_client("target", target));
+			   log_data_client("target", target),
+		           log_data_string("new_username", parv[2]));
 	}
 
 	sendto_server(client, 0, 0, NULL, ":%s CHGIDENT %s %s",

--- a/src/modules/chgident.c
+++ b/src/modules/chgident.c
@@ -135,7 +135,7 @@ CMD_FUNC(cmd_chgident)
 	if (!IsULine(client))
 	{
 		unreal_log(ULOG_INFO, "chgcmds", "CHGIDENT_COMMAND", client,
-		           "CHIDENT: $client changed the username of $target to be $new_username",
+		           "CHIDENT: $client changed the username of $target.details to be $new_username",
 		           log_data_string("change_type", "username"),
 			   log_data_client("target", target),
 		           log_data_string("new_username", parv[2]));

--- a/src/modules/chgname.c
+++ b/src/modules/chgname.c
@@ -98,7 +98,7 @@ CMD_FUNC(cmd_chgname)
 	if (!IsULine(client))
 	{
 		unreal_log(ULOG_INFO, "chgcmds", "CHGHOST_COMMAND", client,
-		           "CHGHOST: $client changed the realname of $target to be $new_realname",
+		           "CHGHOST: $client changed the realname of $target.details to be $new_realname",
 		           log_data_string("change_type", "realname"),
 			   log_data_client("target", target),
 		           log_data_string("new_realname", parv[2]));

--- a/src/modules/chgname.c
+++ b/src/modules/chgname.c
@@ -98,10 +98,10 @@ CMD_FUNC(cmd_chgname)
 	if (!IsULine(client))
 	{
 		unreal_log(ULOG_INFO, "chgcmds", "CHGHOST_COMMAND", client,
-		           "CHGHOST: $client changed the realname of $target.detail to be $new_realname",
+		           "CHGHOST: $client changed the realname of $target to be $new_realname",
 		           log_data_string("change_type", "realname"),
-		           log_data_string("new_realname", parv[2]),
-		           log_data_client("target", target));
+			   log_data_client("target", target),
+		           log_data_string("new_realname", parv[2]));
 	}
 
 	/* set the realname to make ban checking work */


### PR DESCRIPTION
Fixed incorrectly shown chgcmd notices. even though placeholders are used, I am not sure the use of log_data_* functions lets you use these placeholders in any order.
also changed from `$target.detail` to `$target.details`