### PR TITLE
fixed "none" not working as set::level-on-join param

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -7760,7 +7760,7 @@ int	_test_set(ConfigFile *conf, ConfigEntry *ce)
 		else if (!strcmp(cep->name, "level-on-join")) {
 			CheckNull(cep);
 			CheckDuplicate(cep, level_on_join, "level-on-join");
-			if (cep->value == NULL)
+			if (channellevel_to_string(cep->value) == NULL)
 			{
 				config_error("%s:%i: set::level-on-join: unknown value '%s', should be one of: none, voice, halfop, op, admin, owner",
 					cep->file->filename, cep->line_number, cep->value);

--- a/src/conf.c
+++ b/src/conf.c
@@ -699,7 +699,7 @@ char *channellevel_to_string(const char *s)
 	if (!strcmp(s, "owner") || !strcmp(s, "chanowner"))
 		return "q";
 
-	return ""; /* unknown or unsupported */
+	return NULL; /* unknown or unsupported */
 }
 
 Policy policy_strtoval(const char *s)
@@ -7760,7 +7760,7 @@ int	_test_set(ConfigFile *conf, ConfigEntry *ce)
 		else if (!strcmp(cep->name, "level-on-join")) {
 			CheckNull(cep);
 			CheckDuplicate(cep, level_on_join, "level-on-join");
-			if (BadPtr(channellevel_to_string(cep->value)))
+			if (cep->value == NULL)
 			{
 				config_error("%s:%i: set::level-on-join: unknown value '%s', should be one of: none, voice, halfop, op, admin, owner",
 					cep->file->filename, cep->line_number, cep->value);


### PR DESCRIPTION
reported by CaoS
[19:03:29] <CaoS> hello, i have found an error/bug on Unrealircd 6
[19:03:47] <CaoS> in that config: set::level-on-join <none|voice|halfop|op|protect|owner> 
[19:03:55] <CaoS> if you Choose NONE, you get error
[19:04:12] <CaoS> i have tried with OP and works OK, but with NONE you get an error

patch tested on latest beta