### PR TITLE
Lower libmaxminddb requirement from 1.6.0 to 1.2.0

### DIFF
--- a/autoconf/m4/unreal.m4
+++ b/autoconf/m4/unreal.m4
@@ -397,7 +397,7 @@ AC_DEFUN([CHECK_LIBMAXMINDDB],
 	[
 		dnl see if the system provides it
 		has_system_libmaxminddb="no"
-		PKG_CHECK_MODULES([LIBMAXMINDDB], [libmaxminddb >= 1.6.0],
+		PKG_CHECK_MODULES([LIBMAXMINDDB], [libmaxminddb >= 1.2.0],
 		                  [has_system_libmaxminddb=yes])
 		AS_IF([test "x$has_system_libmaxminddb" = "xyes"],
 		[

--- a/configure
+++ b/configure
@@ -8772,12 +8772,12 @@ if test -n "$LIBMAXMINDDB_CFLAGS"; then
     pkg_cv_LIBMAXMINDDB_CFLAGS="$LIBMAXMINDDB_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libmaxminddb >= 1.6.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libmaxminddb >= 1.6.0") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libmaxminddb >= 1.2.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libmaxminddb >= 1.2.0") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_LIBMAXMINDDB_CFLAGS=`$PKG_CONFIG --cflags "libmaxminddb >= 1.6.0" 2>/dev/null`
+  pkg_cv_LIBMAXMINDDB_CFLAGS=`$PKG_CONFIG --cflags "libmaxminddb >= 1.2.0" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -8789,12 +8789,12 @@ if test -n "$LIBMAXMINDDB_LIBS"; then
     pkg_cv_LIBMAXMINDDB_LIBS="$LIBMAXMINDDB_LIBS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libmaxminddb >= 1.6.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libmaxminddb >= 1.6.0") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libmaxminddb >= 1.2.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libmaxminddb >= 1.2.0") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_LIBMAXMINDDB_LIBS=`$PKG_CONFIG --libs "libmaxminddb >= 1.6.0" 2>/dev/null`
+  pkg_cv_LIBMAXMINDDB_LIBS=`$PKG_CONFIG --libs "libmaxminddb >= 1.2.0" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -8815,14 +8815,14 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        LIBMAXMINDDB_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libmaxminddb >= 1.6.0" 2>&1`
+	        LIBMAXMINDDB_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libmaxminddb >= 1.2.0" 2>&1`
         else
-	        LIBMAXMINDDB_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libmaxminddb >= 1.6.0" 2>&1`
+	        LIBMAXMINDDB_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libmaxminddb >= 1.2.0" 2>&1`
         fi
 	# Put the nasty error message in config.log where it belongs
 	echo "$LIBMAXMINDDB_PKG_ERRORS" >&5
 
-	as_fn_error $? "Package requirements (libmaxminddb >= 1.6.0) were not met:
+	as_fn_error $? "Package requirements (libmaxminddb >= 1.2.0) were not met:
 
 $LIBMAXMINDDB_PKG_ERRORS
 


### PR DESCRIPTION
libmaxminddb 1.6.0 was released on 2021-04-29 and is not yet widely available in Linux distributions. However, the alternative GeoIP Legacy C Library will be retired at the end of May 2022 and receives currently only critical security and bug fixes. Upstream recommends to upgrade to GeoIP2 databases, which leads to libmaxminddb when using C.

See also:
 - https://github.com/maxmind/geoip-api-c/blob/main/README.md
 - https://repology.org/project/libmaxminddb/versions