### PR TITLE
help: Change numerics for consistency with other IRCds

### DIFF
--- a/src/modules/help.c
+++ b/src/modules/help.c
@@ -54,8 +54,12 @@ MOD_UNLOAD()
 	return MOD_SUCCESS;
 }
 
-#define HDR(str) sendto_one(client, NULL, ":%s 290 %s :%s", me.name, client->name, str);
-#define SND(str) sendto_one(client, NULL, ":%s 292 %s :%s", me.name, client->name, str);
+// RPL_HELPSTART
+#define HDR(subject, str) sendto_one(client, NULL, ":%s 704 %s %s :%s", me.name, client->name, subject, str);
+// RPL_HELPTXT
+#define SND(subject, str) sendto_one(client, NULL, ":%s 705 %s %s :%s", me.name, client->name, subject, str);
+// RPL_ENDOFHELP
+#define FTR(subject, str) sendto_one(client, NULL, ":%s 706 %s %s :%s", me.name, client->name, subject, str);
 
 ConfigItem_help *find_Help(const char *command)
 {
@@ -89,40 +93,37 @@ void parse_help(Client *client, const char *help)
 		helpitem = find_Help(NULL);
 		if (!helpitem)
 			return;
-		SND(" -");
-		HDR("        ***** UnrealIRCd Help System *****");
-		SND(" -");
+		HDR("*", "        ***** UnrealIRCd Help System *****");
+		SND("*", " -");
 		text = helpitem->text;
 		while (text) {
-			SND(text->line);
+			SND("*", text->line);
 			text = text->next;
 		}
-		SND(" -");
+		FTR("*", " -");
 		return;
 		
 	}
 	helpitem = find_Help(help);
 	if (!helpitem) {
-		SND(" -");
-		HDR("        ***** No Help Available *****");
-		SND(" -");
-		SND("   We're sorry, we don't have help available for the command you requested.");
-		SND(" -");
-		sendto_one(client, NULL, ":%s 292 %s : ***** Go to %s if you have any further questions *****",
-		    me.name, client->name, HELP_CHANNEL);
-		SND(" -");
+		HDR("*", "        ***** No Help Available *****");
+		SND("*", " -");
+		SND("*", "   We're sorry, we don't have help available for the command you requested.");
+		SND("*", " -");
+		sendto_one(client, NULL, ":%s 705 %s * : ***** Go to %s if you have any further questions *****",
+		    me.name, client->name, helpchan);
+		FTR("*", " -");
 		return;
 	}
 	text = helpitem->text;
-	SND(" -");
-	sendto_one(client, NULL, ":%s 290 %s :***** %s *****",
-	    me.name, client->name, helpitem->command);
-	SND(" -");
+	sendto_one(client, NULL, ":%s 704 %s %s :***** %s *****",
+	    me.name, client->name, help, helpitem->command);
+	SND(help, " -");
 	while (text) {
-		SND(text->line);
+		SND(help, text->line);
 		text = text->next;
 	}
-	SND(" -");
+	FTR(help, " -");
 }
 
 /*


### PR DESCRIPTION
This is GH-167, rebased on unreal60_dev.

Screenshots below, with the two versions (first the current one, then the one I'm proposing)

# Looks much better

Konversation:

![konversation_1.8-20121](https://user-images.githubusercontent.com/406946/143763262-81b91359-c86d-427a-b37e-b264062db2cf.png)

KVIrc
![kvirc_5 0 0](https://user-images.githubusercontent.com/406946/143763267-d0e87d13-83e9-49a2-a26f-75405a70471d.png)

# Looks the same

IRCCloud:

![irccloud](https://user-images.githubusercontent.com/406946/143763232-21f4f047-3fe5-495a-af2e-ff1c5ca19343.png)

Srain:

![srain_1.2.4](https://user-images.githubusercontent.com/406946/143763288-0a6a3cbf-574d-47cf-9e38-578f98261cf1.png)


# Looks slightly worse, as the client shows the command name (here, it's `*`) before the text

Gamja:

![gamja](https://user-images.githubusercontent.com/406946/143763752-1bd20dd2-5963-42aa-be6d-8c968c29e42b.png)

Hexchat:

![hexchat_2.14.3](https://user-images.githubusercontent.com/406946/143763212-27d77ca1-f864-44c5-bfdc-8e71eb0e871c.png)

irssi:

![irssi_1.3](https://user-images.githubusercontent.com/406946/143763247-727fdb6e-e5f3-4274-9f9a-b97467e7e6c9.png)

KiwiIRC:

![kiwiirc](https://user-images.githubusercontent.com/406946/143763258-3f6dfc8a-e9d4-4c4a-b653-76c6e1a2cacc.png)

Quassel:

![quassel_0.13.1](https://user-images.githubusercontent.com/406946/143763277-095c6085-a74d-41c1-b067-8fae87de4b8f.png)

Weechat:

![weechat_3.0](https://user-images.githubusercontent.com/406946/143763306-10a184a8-65d9-4c7f-bc83-3f72b3fcd293.png)
