### PR TITLE
wallops: Send a full NUH as prefix in echoed WALLOPS

### DIFF
--- a/src/modules/wallops.c
+++ b/src/modules/wallops.c
@@ -74,7 +74,7 @@ CMD_FUNC(cmd_wallops)
 	}
 
 	if (MyUser(client))
-		sendto_one(client, NULL, ":%s WALLOPS :%s", client->name, message);
+		sendto_prefix_one(client, client, NULL, ":%s WALLOPS :%s", client->name, message);
 
 	sendto_ops_butone(client->direction, client, ":%s WALLOPS :%s", client->name, message);
 }


### PR DESCRIPTION
For consistency with other WALLOPS messages.

This echo was added in 334ce5e1662a49ae2b23a65f85b1c1561fa0be55