### PR TITLE
Add SOURCE_DATE_EPOCH support for build date

### DIFF
--- a/src/version.c.SH
+++ b/src/version.c.SH
@@ -22,7 +22,9 @@ generation=`expr $generation + 1`
 export LANG=C
 export LC_TIME=C
 export LC_ALL=C
-creation=`date | \
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}"
+BUILD_DATE=$(date -u -d "@$SOURCE_DATE_EPOCH" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" 2>/dev/null || date -u)
+creation=`echo "$BUILD_DATE" | \
 awk '{if (NF == 6) \
          { print $1 " "  $2 " " $3 " "  $6 " at " $4 " " $5 } \
 else \


### PR DESCRIPTION
This uses the timestamp in [`$SOURCE_DATE_EPOCH`][1] if set and falls back to the current behavior otherwise. It tries `date -d "@..."` first and falls back to `date -r "..."` to support BSD date(1) too.

I'm not sure if I'm opening this PR to the right branch, let me know and I can rebase if needed.

Thanks!

[1]: https://reproducible-builds.org/docs/source-date-epoch/