### PR TITLE
Add geoip-tag module

### DIFF
--- a/src/modules/geoip-tag.c
+++ b/src/modules/geoip-tag.c
@@ -1,6 +1,6 @@
 /*
  *   IRC - Internet Relay Chat, src/modules/geoip-tag.c
- *   (C) 2020 Syzop & The UnrealIRCd Team
+ *   (C) 2022 westor, Syzop and The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of
  *   the programmers.
@@ -25,15 +25,13 @@
 ModuleHeader MOD_HEADER
   = {
 	"geoip-tag",
-	"5.0",
+	"6.0",
 	"geoip message tag",
 	"UnrealIRCd Team",
 	"unrealircd-6",
 	};
 
-/* Variables */
-long CAP_ACCOUNT_TAG = 0L;
-
+/* Forward declarations */
 int geoip_mtag_is_ok(Client *client, const char *name, const char *value);
 int geoip_mtag_should_send_to_client(Client *target);
 void mtag_add_geoip(Client *client, MessageTag *recv_mtags, MessageTag **mtag_list, const char *signature);
@@ -83,9 +81,9 @@ void mtag_add_geoip(Client *client, MessageTag *recv_mtags, MessageTag **mtag_li
 {
 	MessageTag *m;
 	
-	GeoIPResult *geoip = geoip_lookup(client->ip);
+	GeoIPResult *geoip;
 
-	if (IsUser(client) && geoip)
+	if (IsUser(client) && ((geoip = geoip_client(client))))
 	{
 		MessageTag *m = find_mtag(recv_mtags, "unrealircd.org/geoip");
 		if (m)

--- a/src/modules/geoip-tag.c
+++ b/src/modules/geoip-tag.c
@@ -1,0 +1,110 @@
+/*
+ *   IRC - Internet Relay Chat, src/modules/geoip-tag.c
+ *   (C) 2020 Syzop & The UnrealIRCd Team
+ *
+ *   See file AUTHORS in IRC package for additional names of
+ *   the programmers.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 1, or (at your option)
+ *   any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "unrealircd.h"
+
+ModuleHeader MOD_HEADER
+  = {
+	"geoip-tag",
+	"5.0",
+	"geoip message tag",
+	"UnrealIRCd Team",
+	"unrealircd-6",
+	};
+
+/* Variables */
+long CAP_ACCOUNT_TAG = 0L;
+
+int geoip_mtag_is_ok(Client *client, const char *name, const char *value);
+int geoip_mtag_should_send_to_client(Client *target);
+void mtag_add_geoip(Client *client, MessageTag *recv_mtags, MessageTag **mtag_list, const char *signature);
+
+MOD_INIT()
+{
+	MessageTagHandlerInfo mtag;
+
+	MARK_AS_OFFICIAL_MODULE(modinfo);
+
+	memset(&mtag, 0, sizeof(mtag));
+	mtag.name = "unrealircd.org/geoip";
+	mtag.is_ok = geoip_mtag_is_ok;
+	mtag.should_send_to_client = geoip_mtag_should_send_to_client;
+	mtag.flags = MTAG_HANDLER_FLAGS_NO_CAP_NEEDED;
+	MessageTagHandlerAdd(modinfo->handle, &mtag);
+
+	HookAddVoid(modinfo->handle, HOOKTYPE_NEW_MESSAGE, 0, mtag_add_geoip);
+
+	return MOD_SUCCESS;
+}
+
+MOD_LOAD()
+{
+	return MOD_SUCCESS;
+}
+
+MOD_UNLOAD()
+{
+	return MOD_SUCCESS;
+}
+
+/** This function verifies if the client sending
+ * 'geoip-tag' is permitted to do so and uses a permitted
+ * syntax.
+ * We simply allow geoip-tag ONLY from servers and with any syntax.
+ */
+int geoip_mtag_is_ok(Client *client, const char *name, const char *value)
+{
+	if (IsServer(client))
+		return 1;
+
+	return 0;
+}
+
+void mtag_add_geoip(Client *client, MessageTag *recv_mtags, MessageTag **mtag_list, const char *signature)
+{
+	MessageTag *m;
+	
+	GeoIPResult *geoip = geoip_lookup(client->ip);
+
+	if (IsUser(client) && geoip)
+	{
+		MessageTag *m = find_mtag(recv_mtags, "unrealircd.org/geoip");
+		if (m)
+		{
+			m = duplicate_mtag(m);
+		} else {
+			m = safe_alloc(sizeof(MessageTag));
+			safe_strdup(m->name, "unrealircd.org/geoip");
+			safe_strdup(m->value, geoip->country_code);
+		}
+		AddListItem(m, *mtag_list);
+	}
+}
+
+/** Outgoing filter for this message tag */
+int geoip_mtag_should_send_to_client(Client *target)
+{
+	if (IsServer(target) || IsOper(target))
+		return 1;
+
+	return 0;
+}


### PR DESCRIPTION
This module will work the same way as `userip-tag` or `userhost-tag` modules work now, the 90% of this code is part from these modules, it will help especially the irc bots (AdiIRC/mIRC/etc..) to detect the geoip country code directly and easy when someone is talking on a channel and take actions, i hope this will help on most people.

Thanks to @ValwareIRC  for testing it out.

Short Example: `@unrealircd.org/geoip=GR;account=tester;msgid=tPTHDgymv9pgdGdYkI3WBd;time=2022-03-30T16:34:26.780Z :tester!Username@3765DB68:3AE9CB6C:B0540131:IP PRIVMSG #Test :test message`

- Thanks!