### PR TITLE
Undocument the long dead SVSO feature.

### DIFF
--- a/doc/conf/help/help.conf
+++ b/doc/conf/help/help.conf
@@ -80,8 +80,8 @@ help Svscmds {
 	" SQLINE          SVSKILL         SVSNLINE    SVSSILENCE";
 	" SVS2MODE        SVSLUSERS       SVSNOLAG    SVSSNO";
 	" SVS2SNO         SVSMODE         SVSNOOP     SVSWATCH";
-	" SVSFLINE        SVSMOTD         SVSO        SWHOIS";
-	" SVSJOIN         SVSNICK         SVSPART     UNSQLINE";
+	" SVSFLINE        SVSMOTD         SWHOIS      SVSJOIN";
+	" SVSNICK         SVSPART         UNSQLINE";
 	" ==-------------------------oOo-------------------------==";
 }
 
@@ -1270,16 +1270,6 @@ help Svspart {
 	" Example: SVSPART hAtbLaDe #Hanson";
 	"          SVSPART hAtbLaDe #Hanson,#AOL";
 	"          SVSPART hAtbLaDe #Hanson,#AOL You must leave";
-}
-
-help Svso {
-	" Gives nick Operflags like the ones in O-Lines.";
-	" Remember to set SVSMODE +o and alike.";
-	" Must be sent through an U-Lined server.";
-	" -";
-	" Syntax:  SVSO <nick> <+operflags> (Adds the Operflags)";
-	"          SVSO <nick> - (Removes all O-Line flags)";
-	" Example: SVSO SomeNick +bBkK";
 }
 
 help Swhois {

--- a/doc/conf/help/help.de.conf
+++ b/doc/conf/help/help.de.conf
@@ -82,8 +82,8 @@ help Svscmds {
       " SQLINE          SVSKILL         SVSNLINE    SVSSILENCE";
       " SVS2MODE        SVSLUSERS       SVSNOLAG    SVSSNO";
       " SVS2SNO         SVSMODE         SVSNOOP     SVSWATCH";
-      " SVSFLINE        SVSMOTD         SVSO        SWHOIS";
-      " SVSJOIN         SVSNICK         SVSPART     UNSQLINE";
+      " SVSFLINE        SVSMOTD         SWHOIS      SVSJOIN";
+      " SVSNICK         SVSPART         UNSQLINE";
 	" ==-------------------------oOo-------------------------==";
 }
 
@@ -1180,16 +1180,6 @@ help Svspart {
 	" Beispiel: SVSPART hAtbLaDe #Hanson";
 	"          SVSPART hAtbLaDe #Hanson,#AOL";
 	"          SVSPART hAtbLaDe #Hanson,#AOL Und weg auch....";
-}
-
-help Svso {
-	" Gibt dem Nick Operflags wie die in den O:lines.";
-	" Normale Flags wie +O sind durch SVSMODE zu setzen.";
-	" Muss durch einen U:Lined Server gesendet werden.";
-	" -";
-	" Syntax:  SVSO <nick> <+operflags> (Setzt die Operflags)";
-	"          SVSO <nick> - (Löscht alle O:Line Flags)";
-	" Beispiel: SVSO SomeNick +bBkK";
 }
 
 help Swhois {

--- a/doc/conf/help/help.es.conf
+++ b/doc/conf/help/help.es.conf
@@ -93,8 +93,8 @@ help Svscmds {
 	" SQLINE          SVSKILL         SVSNLINE    SVSSILENCE";
 	" SVS2MODE        SVSLUSERS       SVSNOLAG    SVSSNO";
 	" SVS2SNO         SVSMODE         SVSNOOP     SVSWATCH";
-	" SVSFLINE        SVSMOTD         SVSO        SWHOIS";
-	" SVSJOIN         SVSNICK         SVSPART     UNSQLINE";
+	" SVSFLINE        SVSMOTD         SWHOIS      SVSJOIN";
+	" SVSNICK         SVSPART         UNSQLINE";
 	" ==-------------------------oOo-------------------------==";
 };
 
@@ -1248,16 +1248,6 @@ help Svspart {
 	" Ejemplos:  SVSPART hAtbLaDe #Hanson";
 	"            SVSPART hAtbLaDe #Hanson,#AOL";
 	"            SVSPART hAtbLaDe #Hanson,#AOL Debes irte";
-};
-
-help Svso {
-	" Otorga al nick usado Operflags como las O-Lines..";
-	" Recuerde configurar SVSMODE +o y similares.";
-	" Debe enviarse a través de un servidor con U-Lines.";
-	" -";
-	" Sintaxis:  SVSO <nick> <+operflags> (añade los Operflags)";
-	"            SVSO <nick> - (elimina todos los flags de O-Line)";
-	" Ejemplo:   SVSO SomeNick +bBkK";
 };
 
 help Swhois {

--- a/doc/conf/help/help.fr.conf
+++ b/doc/conf/help/help.fr.conf
@@ -83,8 +83,8 @@ help Svscmds {
 	" SQLINE          SVSKILL         SVSNLINE    SVSSILENCE";
 	" SVS2MODE        SVSLUSERS       SVSNOLAG    SVSSNO";
 	" SVS2SNO         SVSMODE         SVSNOOP     SVSWATCH";
-	" SVSFLINE        SVSMOTD         SVSO        SWHOIS";
-	" SVSJOIN         SVSNICK         SVSPART     UNSQLINE";
+	" SVSFLINE        SVSMOTD         SWHOIS      SVSJOIN";
+	" SVSNICK         SVSPART         UNSQLINE";
 	" ==-------------------------oOo-------------------------==";
 }
 
@@ -1200,16 +1200,6 @@ help Svspart {
 	" Exemple : SVSPART hAtbLaDe #Hanson";
 	"          SVSPART hAtbLaDe #Hanson,#AOL";
 	"          SVSPART hAtbLaDe #Hanson,#AOL You must leave";
-}
-
-help Svso {
-	" Donne à un pseudo des Operflags tels que ceux dans les O:lines.";
-	" Il faudra aussi appliquer SVSMODE +o et semblables.";
-	" Doit être envoyé à travers un serveur avec U:Line.";
-	" -";
-	" Syntaxe : SVSO <pseudo> <+operflags> (Ajoute les Operflags)";
-	"           SVSO <pseudo> - (Retire tous les flags O:Line)";
-	" Exemple : SVSO SomeNick +bBkK";
 }
 
 help Swhois {

--- a/doc/conf/help/help.it.conf
+++ b/doc/conf/help/help.it.conf
@@ -82,8 +82,8 @@ help Svscmds {
 	" SQLINE          SVSKILL         SVSNLINE    SVSSILENCE";
 	" SVS2MODE        SVSLUSERS       SVSNOLAG    SVSSNO";
 	" SVS2SNO         SVSMODE         SVSNOOP     SVSWATCH";
-	" SVSFLINE        SVSMOTD         SVSO        SWHOIS";
-	" SVSJOIN         SVSNICK         SVSPART     UNSQLINE";
+	" SVSFLINE        SVSMOTD         SWHOIS      SVSJOIN";
+	" SVSNICK         SVSPART         UNSQLINE";
 	" ==-------------------------oOo-------------------------==";
 }
 
@@ -1113,16 +1113,6 @@ help Svspart {
 	" Esempio: SVSPART Ugo #Hanson";
 	"          SVSPART Ugo #Hanson,#AOL";
 	"          SVSPART Ugo #Hanson,#AOL Accesso non ammesso";
-}
-
-help Svso {
-	" Assegna all'utente delle operflag come quelle nelle operclass.";
-	" Da usare in associazione con SVSMODE +o per assegnare il grado di Oper.";
-	" Deve essere inviato tramite un server U:Lined.";
-	" -";
-	" Sintassi:  SVSO <nick> <+operflags> (aggiunge le operflag)";
-	"          SVSO <nick> - (rimuove tutte le operflag)";
-	" Esempio: SVSO Ugo +bBkK";
 }
 
 help Swhois {

--- a/doc/conf/help/help.nl.conf
+++ b/doc/conf/help/help.nl.conf
@@ -81,8 +81,8 @@ help Svscmds {
 	" SQLINE          SVSKILL         SVSNLINE    SVSSILENCE";
 	" SVS2MODE        SVSLUSERS       SVSNOLAG    SVSSNO";
 	" SVS2SNO         SVSMODE         SVSNOOP     SVSWATCH";
-	" SVSFLINE        SVSMOTD         SVSO        SWHOIS";
-	" SVSJOIN         SVSNICK         SVSPART     UNSQLINE";
+	" SVSFLINE        SVSMOTD         SWHOIS      SVSJOIN";
+	" SVSNICK         SVSPART         UNSQLINE";
 	" ==-------------------------oOo-------------------------==";
 }
 
@@ -1247,16 +1247,6 @@ help Svspart {
 	" Voorbeeld: SVSPART hAtbLaDe #Hanson";
 	"          SVSPART hAtbLaDe #Hanson,#AOL";
 	"          SVSPART hAtbLaDe #Hanson,#AOL Je moet weggaan";
-}
-
-help Svso {
-	" Geeft nick Operflags zoals die in O-Lines.";
-	" Vergeet niet om SVSMODE +o en dergelijke in te stellen.";
-	" Moet via een U-Lined server worden verstuurd.";
-	" -";
-	" Syntaxis:  SVSO <nick> <+operflags> (Voegt de Operflags toe)";
-	"          SVSO <nick> - (Verwijdert alle O-Line vlaggen)";
-	" Voorbeeld: SVSO SomeNick +bBkK";
 }
 
 help Swhois {

--- a/doc/conf/help/help.pl.conf
+++ b/doc/conf/help/help.pl.conf
@@ -85,8 +85,8 @@ help Svscmds {
 	" SQLINE          SVSKILL         SVSNLINE    SVSSILENCE";
 	" SVS2MODE        SVSLUSERS       SVSNOLAG    SVSSNO";
 	" SVS2SNO         SVSMODE         SVSNOOP     SVSWATCH";
-	" SVSFLINE        SVSMOTD         SVSO        SWHOIS";
-	" SVSJOIN         SVSNICK         SVSPART     UNSQLINE";
+	" SVSFLINE        SVSMOTD         SWHOIS      SVSJOIN";
+	" SVSNICK         SVSPART         UNSQLINE";
 	" ==-------------------------oOo-------------------------==";
 }
 
@@ -1323,16 +1323,6 @@ help Svspart {
 	" Przykład: SVSPART hAtbLaDe #Hanson";
 	"           SVSPART hAtbLaDe #Hanson,#AOL";
 	"           SVSPART hAtbLaDe #Hanson,#AOL Musisz wyjść";
-}
-
-help Svso {
-	" Daje użytkownikowi flagi operatora, podobnie, jak robi O-Line.";
-	" Pamiętaj o ustawieniu SVSMODE +o i podobnych.";
-	" Komenda musi być wysłana przez serwer mający ustawienie U-Line.";
-	" -";
-	" Składnia: SVSO <nick> <+flagi_oper> (Dodaje flagi operatora)";
-	"           SVSO <nick> - (Usuwa wszystkie flagi)";
-	" Przykład: SVSO SomeNick +bBkK";
 }
 
 help Swhois {

--- a/doc/conf/help/help.ru.conf
+++ b/doc/conf/help/help.ru.conf
@@ -85,8 +85,8 @@ help Svscmds {
 	" SQLINE          SVSKILL         SVSNLINE    SVSSILENCE";
 	" SVS2MODE        SVSLUSERS       SVSNOLAG    SVSSNO";
 	" SVS2SNO         SVSMODE         SVSNOOP     SVSWATCH";
-	" SVSFLINE        SVSMOTD         SVSO        SWHOIS";
-	" SVSJOIN         SVSNICK         SVSPART     UNSQLINE";
+	" SVSFLINE        SVSMOTD         SWHOIS      SVSJOIN";
+	" SVSNICK         SVSPART         UNSQLINE";
 	" ==-------------------------oOo-------------------------==";
 }
 
@@ -1361,16 +1361,6 @@ help Svspart {
 	" Пример:     SVSPART hAtbLaDe #Hanson";
 	"             SVSPART hAtbLaDe #Hanson,#AOL";
 	"             SVSPART hAtbLaDe #Hanson,#AOL You must leave";
-}
-
-help Svso {
-	" Даёт пользователю Operflags как описано в O:lines.";
-	" Не забывайте указывать SVSMODE +o и им подобные.";
-	" Должно использоваться через сервер, описанный в U:Lines.";
-	" -";
-	" Синтаксис:  SVSO <nick> <+operflags> (Добавляет Operflags)";
-	"             SVSO <nick> - (Снимает все O:Line флаги)";
-	" Пример:     SVSO SomeNick +bBkK";
 }
 
 help Swhois {

--- a/doc/conf/help/help.tr.conf
+++ b/doc/conf/help/help.tr.conf
@@ -84,8 +84,8 @@ help Svscmds {
 	" SQLINE          SVSKILL         SVSNLINE    SVSSILENCE";
 	" SVS2MODE        SVSLUSERS       SVSNOLAG    SVSSNO";
 	" SVS2SNO         SVSMODE         SVSNOOP     SVSWATCH";
-	" SVSFLINE        SVSMOTD         SVSO        SWHOIS";
-	" SVSJOIN         SVSNICK         SVSPART     UNSQLINE";
+	" SVSFLINE        SVSMOTD         SWHOIS      SVSJOIN";
+	" SVSNICK         SVSPART         UNSQLINE";
 	" ==-------------------------oOo-------------------------==";
 }
 
@@ -1258,16 +1258,6 @@ help Svspart {
 	" Örnek:     SVSPART hAtbLaDe #Hanson";
 	"            SVSPART hAtbLaDe #Hanson,#AOL";
 	"            SVSPART hAtbLaDe #Hanson,#AOL Sen çıkmalısın";
-}
-
-help Svso {
-	" Bu komut, bir kullanıcıya O:lines yetkilisi gibi IRCop flagları verir.";
-	" Svsmode +o ve benzeri komutları hatırlayınız.";
-	" Sadece U:Lined (Servisler)'den gönderilebilir.";
-	" -";
-	" Kullanımı: SVSO <nick> <+oper-flagları> (OPER flagları ekler.)";
-	"            SVSO <nick> - (O:Line flaglarını siler.)";
-	" Örnek:     SVSO SomeNick +bBkK";
 }
 
 help Swhois {

--- a/include/msg.h
+++ b/include/msg.h
@@ -137,7 +137,6 @@
 #define MSG_SAPART 	"SAPART"
 #define MSG_CHGIDENT 	"CHGIDENT"
 #define MSG_SWHOIS 	"SWHOIS"
-#define MSG_SVSO 	"SVSO"
 #define MSG_SVSFLINE 	"SVSFLINE"
 #define MSG_TKL		"TKL"
 #define MSG_VHOST 	"VHOST"


### PR DESCRIPTION
The SVSO feature was removed in [2015](https://github.com/unrealircd/unrealircd/commit/0f2af3f506613cf601341965f04fb388a4f227fd) but still remained documented.

This has confused some users who wanted to know why the Anope feature which depended on this did not work on UnrealIRCd 4+.