### PR TITLE
Add IRCv3 Channel Context mtag

### DIFF
--- a/Makefile.windows
+++ b/Makefile.windows
@@ -381,6 +381,7 @@ DLL_FILES=\
  src/modules/trace.dll \
  src/modules/tsctl.dll \
  src/modules/typing-indicator.dll \
+ src/modules/channel-context.dll \
  src/modules/umode2.dll \
  src/modules/unreal_server_compat.dll \
  src/modules/unsqline.dll \
@@ -1213,6 +1214,9 @@ src/modules/tsctl.dll: src/modules/tsctl.c $(INCLUDES)
 
 src/modules/typing-indicator.dll: src/modules/typing-indicator.c $(INCLUDES)
 	$(CC) $(MODCFLAGS) src/modules/typing-indicator.c /Fesrc/modules/ /Fosrc/modules/ /Fdsrc/modules/typing-indicator.pdb $(MODLFLAGS)
+
+src/modules/channel-context.dll: src/modules/channel-context.c $(INCLUDES)
+	$(CC) $(MODCFLAGS) src/modules/channel-context.c /Fesrc/modules/ /Fosrc/modules/ /Fdsrc/modules/channel-context.pdb $(MODLFLAGS)
 
 src/modules/umode2.dll: src/modules/umode2.c $(INCLUDES)
 	$(CC) $(MODCFLAGS) src/modules/umode2.c /Fesrc/modules/ /Fosrc/modules/ /Fdsrc/modules/umode2.pdb $(MODLFLAGS)

--- a/doc/conf/modules.default.conf
+++ b/doc/conf/modules.default.conf
@@ -218,6 +218,7 @@ loadmodule "echo-message"; /* shows clients if their messages are altered/filter
 loadmodule "labeled-response"; /* correlate requests and responses easily */
 loadmodule "bot-tag"; /* indicate the message comes from a bot (draft/bot) */
 loadmodule "typing-indicator"; /* typing indicator in PM and channels (+typing) */
+loadmodule "channel-context";
 loadmodule "reply-tag"; /* indicate to which message you are responding (+draft/reply) */
 loadmodule "clienttagdeny"; /* informs clients about supported client-only message tags */
 loadmodule "sts"; /* strict transport policy (set::tls::sts-policy) */

--- a/src/modules/Makefile.in
+++ b/src/modules/Makefile.in
@@ -73,7 +73,7 @@ MODULES= \
 	message-ids.so plaintext-policy.so server-time.so sts.so \
 	echo-message.so userip-tag.so userhost-tag.so geoip-tag.so \
 	bot-tag.so reply-tag.so json-log-tag.so \
-	typing-indicator.so \
+	typing-indicator.so channel-context.so \
 	ident_lookup.so history.so chathistory.so \
 	targetfloodprot.so clienttagdeny.so watch-backend.so \
 	monitor.so slog.so tls_cipher.so operinfo.so \

--- a/src/modules/channel-context.c
+++ b/src/modules/channel-context.c
@@ -63,14 +63,12 @@ MOD_UNLOAD()
 
 int chancontext_mtag_is_ok(Client *client, const char *name, const char *value)
 {
-	
+	Channel *channel;
+
 	if (BadPtr(value))
 		return 0;
-
-	if (!strlen(value))
-		return 0;
 	
-	Channel *channel = find_channel(value);
+	channel = find_channel(value);
 
 	if (!channel)
 		return 0;

--- a/src/modules/channel-context.c
+++ b/src/modules/channel-context.c
@@ -1,0 +1,98 @@
+/*
+ *   IRC - Internet Relay Chat, src/modules/channel-context.c
+ *   (C) 2022 Valware & The UnrealIRCd Team
+ *
+ *   See file AUTHORS in IRC package for additional names of
+ *   the programmers.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 1, or (at your option)
+ *   any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "unrealircd.h"
+
+ModuleHeader MOD_HEADER
+  = {
+	"channel-context",
+	"1.0",
+	"Channel Context (IRCv3)",
+	"UnrealIRCd team",
+	"unrealircd-6",
+	};
+
+int chancontext_mtag_is_ok(Client *client, const char *name, const char *value);
+void mtag_add_chancontext(Client *client, MessageTag *recv_mtags, MessageTag **mtag_list, const char *signature);
+
+MOD_INIT()
+{
+	MessageTagHandlerInfo mtag;
+
+	MARK_AS_OFFICIAL_MODULE(modinfo);
+
+	memset(&mtag, 0, sizeof(mtag));
+	mtag.is_ok = chancontext_mtag_is_ok;
+	mtag.flags = MTAG_HANDLER_FLAGS_NO_CAP_NEEDED;
+	mtag.name = "+draft/channel-context";
+	MessageTagHandlerAdd(modinfo->handle, &mtag);
+
+	HookAddVoid(modinfo->handle, HOOKTYPE_NEW_MESSAGE, 0, mtag_add_chancontext);
+
+	return MOD_SUCCESS;
+}
+
+MOD_LOAD()
+{
+	return MOD_SUCCESS;
+}
+
+MOD_UNLOAD()
+{
+	return MOD_SUCCESS;
+}
+
+int chancontext_mtag_is_ok(Client *client, const char *name, const char *value)
+{
+	
+	if (BadPtr(value))
+		return 0;
+
+	Client *v = find_user("Valware", NULL);
+
+	if (!strlen(value))
+		return 0;
+	Channel *channel = find_channel(value);
+
+	if (!channel)
+		return 0;
+	
+	if (!IsMember(client, channel) && !IsULine(client))
+		return 0;
+		
+	return 1;
+}
+
+void mtag_add_chancontext(Client *client, MessageTag *recv_mtags, MessageTag **mtag_list, const char *signature)
+{
+	MessageTag *m;
+
+	if (IsUser(client))
+	{
+		m = find_mtag(recv_mtags, "+draft/channel-context");
+		if (m)
+		{
+			m = duplicate_mtag(m);
+			AddListItem(m, *mtag_list);
+		}
+	}
+}

--- a/src/modules/channel-context.c
+++ b/src/modules/channel-context.c
@@ -67,10 +67,9 @@ int chancontext_mtag_is_ok(Client *client, const char *name, const char *value)
 	if (BadPtr(value))
 		return 0;
 
-	Client *v = find_user("Valware", NULL);
-
 	if (!strlen(value))
 		return 0;
+	
 	Channel *channel = find_channel(value);
 
 	if (!channel)


### PR DESCRIPTION
This module allows contexting channels in mtags using `+draft/channel-context`
The sender must be in the channel in order to use it as a context.
U-Lines are exempt from this restriction.