### PR TITLE
Fix webredir by single quotes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -196,6 +196,9 @@ install: all
 	-@if [ ! -f "$(DESTDIR)@CONFDIR@/badwords.conf" ] ; then \
 		$(INSTALL) -m 0600 doc/conf/badwords.conf $(DESTDIR)@CONFDIR@ ; \
 	fi
+    -@if [ ! -f "$(DESTDIR)@CONFDIR@/history.conf" ] ; then \
+		$(INSTALL) -m 0600 doc/conf/history.conf $(DESTDIR)@CONFDIR@ ; \
+	fi
 	-@if [ ! -f "$(DESTDIR)@CONFDIR@/dccallow.conf" ] ; then \
 		$(INSTALL) -m 0600 doc/conf/dccallow.conf $(DESTDIR)@CONFDIR@ ; \
 	fi

--- a/doc/conf/examples/example.conf
+++ b/doc/conf/examples/example.conf
@@ -51,6 +51,7 @@ include "badwords.conf";
 //include "spamfilter.conf";
 include "operclass.default.conf";
 include "snomasks.default.conf";
+//include "history.conf";
 
 /* Load the default cloaking module (2021 onwards): */
 loadmodule "cloak_sha256";

--- a/doc/conf/examples/example.es.conf
+++ b/doc/conf/examples/example.es.conf
@@ -50,7 +50,8 @@ include "help/help.conf";
 include "badwords.conf";
 //include "spamfilter.conf";
 include "operclass.default.conf";
-include "snomasks.default.conf";
+//include "history.conf";
+
 
 /* Cargar el módulo de encubrimiento predeterminado (2021 en adelante): */
 loadmodule "cloak_sha256";

--- a/doc/conf/examples/example.fr.conf
+++ b/doc/conf/examples/example.fr.conf
@@ -52,6 +52,7 @@ include "badwords.conf";
 //include "spamfilter.conf";
 include "operclass.default.conf";
 include "snomasks.default.conf";
+//include "history.conf";
 
 /* Load the default cloaking module (2021 onwards): */
 loadmodule "cloak_sha256";

--- a/doc/conf/examples/example.tr.conf
+++ b/doc/conf/examples/example.tr.conf
@@ -52,6 +52,7 @@ include "badwords.conf";
 //include "spamfilter.conf";
 include "operclass.default.conf";
 include "snomasks.default.conf";
+//include "history.conf";
 
 /* Load the default cloaking module (2021 onwards): */
 loadmodule "cloak_sha256";

--- a/doc/conf/history.conf
+++ b/doc/conf/history.conf
@@ -1,0 +1,87 @@
+ /* Configure settings related to Channel history:
+ * https://www.unrealircd.org/docs/Channel_history
+ * 
+ * https://www.unrealircd.org/docs/Set_block#set::history
+ *
+ * The set::history::channel::playback-on-join block describes the behavior
+ * when a user joins a +H channel. 
+ *
+ * The set::history::channel::max-storage-per-channel block sets limits on what
+ * can be set via /MODE #chan +H.
+ *
+ * Note that these are separate things:
+ * only a few lines of history are shown on-join, many more lines can be 
+ * fetched via the HISTORY command (and possibly other commands in the future).
+ *
+ * This shows the default settings:
+ */
+set {
+    history {
+        channel {
+            /* How many lines to playback on join? */
+            playback-on-join {
+                lines 15;
+                time 1d;
+            }
+            /* How much history to keep. These are the
+             * upper maximums for channel mode +H lines:time
+             */
+            max-storage-per-channel {
+                /* +r channels have larger maximums: */
+                registered {
+                    lines 5000;
+                    time 31d;
+                }
+                /* -r channels have less: */
+                unregistered {
+                    lines 200;
+                    time 31d;
+                }
+            }
+        }
+    }
+}
+/* 
+ * Persistent channel history
+ *
+ * You can also store channel history encrypted on disk.
+ * This means channel history is preserved across IRCd restarts.
+ * UnrealIRCd will only store channel history for channels that have both
+ * channel mode +H and +P set.
+ *
+ * To enable this you need to create a Secret block like this:
+ * This is only a simple example with passwords stored directly in the
+ * configuration file.
+ *
+ * To get better security, read https://www.unrealircd.org/docs/Secret_block
+ * on alternative ways so you don't store passwords directly in the config.
+ */
+secret historydb {
+        password "somepassword";
+}
+
+/*
+ * And then refer to that secret block which we named historydb:
+ */
+set {
+    history {
+        channel {
+            persist yes;
+            db-secret "historydb";
+        }
+    }
+}
+/* 
+ * UnrealIRCd has the following goals for storing channel history on disk:
+ *
+ * - All data within the .db's is encrypted
+ * - We use a well-known encryption library, a good cipher and KDF,
+ *   see Dev:UnrealDB for in-depth technical details.
+ * - By default the log databases are stored in the data/history/ directory
+ * - All .db files are cryptographically hashed so a third party can't tell
+ *   which .db file belongs to which channel
+ * - A 'master.db' file is present too, to achieve the above in a consistent
+ *   and safe manner. Don't delete this file.
+ * - Be sure to look at Secret block to see the various ways to store the key 
+ *   (password) and pick one acceptable to your environment
+ */

--- a/doc/conf/modules.optional.conf
+++ b/doc/conf/modules.optional.conf
@@ -133,7 +133,7 @@ set {
 //loadmodule "webredir";
 //set {
 //	webredir {
-//		url "https://...";
+//		url 'https://...';
 //	}
 //}
 


### PR DESCRIPTION
need single quotes rather than double quotes because unreal will try to download.need single quotes rather than double quotes because unreal will try to download. Try error with "http://www.extra-cool.fr"

> 
> [25-05/23:43] <ZarTek> Hi, an little bug in set { webredir { url "https://www.extra-cool.fr/"; } } return "set::webredir::url needs to be a valid URL" because contains an " - " in domain name. I don't know why he rejected on the condition: if (!strstr(cep->value, "://") || !strcmp(cep->value, "https://..."))
> [25-05/23:49] <ZarTek> UnrealIRCd-6.0.3.
> [25-05/23:51] <alice> ZarTek, you may need single quotes there rather than double quotes, as unreal will try and download the page and use /that/ as the value if it's double i think
> [25-05/23:54] * Joins: sAn (~sAn@Clk-EC2D4344.clients.your-server.de)
> [25-05/23:55] <ZarTek> alice: It seems very possible to me. I'll try. Thank you for your reply.
> [25-05/23:56] <@Valware> =]
> [25-05/23:58] <ZarTek> Yes, it works, very good deductions from you. Although such behavior was unexpected in this value.
> [26-05/00:07] <@Valware> indeed, on the wiki it has specified with double-quotes when in fact it expects single-quotes to work. so I edited it :D
> [26-05/00:07] <@Valware> https://www.unrealircd.org/docs/Set_block#set::webredir::url
> [26-05/00:07] <@Valware> =]