### PR TITLE
Fix SWHOIS lines hidden when hideoper is 1/true

### DIFF
--- a/src/modules/whois.c
+++ b/src/modules/whois.c
@@ -614,7 +614,7 @@ CMD_FUNC(cmd_whois)
 			                    target->name, "is shunned");
 		}
 
-		if (target->user->swhois && !hideoper && (whois_get_policy(client, target, "swhois") > WHOIS_CONFIG_DETAILS_NONE))
+		if (target->user->swhois && (whois_get_policy(client, target, "swhois") > WHOIS_CONFIG_DETAILS_NONE))
 		{
 			SWhois *s;
 			int swhois_lines = 0;


### PR DESCRIPTION
it seems a unrealircd deals with hiding and showing oper based on `hideoper` usermode on line 511, and has other part here been hiding swhois lines if hideoper were true, which doesn't feel like desired behaviour (apologies if wrong).