### PR TITLE
Add support for the stable 'bot' mtag

### DIFF
--- a/src/modules/bot-tag.c
+++ b/src/modules/bot-tag.c
@@ -46,6 +46,12 @@ MOD_INIT()
 	MARK_AS_OFFICIAL_MODULE(modinfo);
 
 	memset(&mtag, 0, sizeof(mtag));
+	mtag.name = "bot";
+	mtag.is_ok = bottag_mtag_is_ok;
+	mtag.flags = MTAG_HANDLER_FLAGS_NO_CAP_NEEDED;
+	MessageTagHandlerAdd(modinfo->handle, &mtag);
+
+	memset(&mtag, 0, sizeof(mtag));
 	mtag.name = "draft/bot";
 	mtag.is_ok = bottag_mtag_is_ok;
 	mtag.flags = MTAG_HANDLER_FLAGS_NO_CAP_NEEDED;
@@ -82,7 +88,14 @@ void mtag_add_bottag(Client *client, MessageTag *recv_mtags, MessageTag **mtag_l
 
 	if (IsUser(client) && has_user_mode(client, 'B'))
 	{
-		MessageTag *m = safe_alloc(sizeof(MessageTag));
+		MessageTag *m;
+
+		m = safe_alloc(sizeof(MessageTag));
+		safe_strdup(m->name, "bot");
+		m->value = NULL;
+		AddListItem(m, *mtag_list);
+
+		m = safe_alloc(sizeof(MessageTag));
 		safe_strdup(m->name, "draft/bot");
 		m->value = NULL;
 		AddListItem(m, *mtag_list);


### PR DESCRIPTION
https://ircv3.net/specs/extensions/bot-mode was ratified a few months ago
(https://github.com/ircv3/ircv3-specifications/pull/495)

This commit keeps the draft mtag in addition to the stable one, for now.