### PR TITLE
Adjust tkl too broad ban detection to avoid banning too-wide IPv6 masks.

### DIFF
--- a/src/modules/tkl.c
+++ b/src/modules/tkl.c
@@ -1203,7 +1203,7 @@ int ban_too_broad(char *usermask, char *hostmask)
 	 * CIDR mask will also pass this test (which is fine).
 	 */
 	for (p = hostmask; *p; p++)
-		if (*p != '*' && *p != '.' && *p != '?')
+		if (*p != '*' && *p != '.' && *p != '?' && *p != ':')
 			cnt++;
 
 	if (cnt >= 4)


### PR DESCRIPTION
This adjusts the test to disallow a ban on `*@*:*:*:*:*`, to bring it into line with similar behaviour for IPv4.