### PR TITLE
Oper message tag

### DIFF
--- a/Makefile.windows
+++ b/Makefile.windows
@@ -1334,3 +1334,5 @@ src/modules/whowas.dll: src/modules/whowas.c $(INCLUDES)
 src/modules/whox.dll: src/modules/whox.c $(INCLUDES)
 	$(CC) $(MODCFLAGS) src/modules/whox.c /Fesrc/modules/ /Fosrc/modules/ /Fdsrc/modules/whox.pdb $(MODLFLAGS)
 
+src/modules/oper-tag.dll: src/modules/oper-tag.c $(INCLUDES)
+	$(CC) $(MODCFLAGS) src/modules/oper-tag.c /Fesrc/modules/ /Fosrc/modules/ /Fdsrc/modules/oper-tag.pdb $(MODLFLAGS)

--- a/doc/conf/modules.default.conf
+++ b/doc/conf/modules.default.conf
@@ -228,7 +228,7 @@ loadmodule "plaintext-policy"; /* plaintext-policy announce */
 loadmodule "chathistory"; /* CHATHISTORY client command, 005 and a CAP (draft) */
 loadmodule "monitor"; /* MONITOR command with functionality similar to WATCH */
 loadmodule "extended-monitor"; /* add away status, gecos and userhost changes to MONITOR (draft) */
-
+loadmodule "oper-tag"; /* draft/oper, unrealircd.org/opername, unrealircd.org/operclass */
 
 /*** Other ***/
 // These are modules that don't fit in any of the previous sections

--- a/src/modules/Makefile.in
+++ b/src/modules/Makefile.in
@@ -73,7 +73,7 @@ MODULES= \
 	account-tag.so labeled-response.so link-security.so \
 	message-ids.so plaintext-policy.so server-time.so sts.so \
 	echo-message.so userip-tag.so userhost-tag.so geoip-tag.so \
-	bot-tag.so reply-tag.so json-log-tag.so \
+	bot-tag.so reply-tag.so json-log-tag.so oper-tag.so \
 	typing-indicator.so channel-context.so \
 	ident_lookup.so history.so chathistory.so \
 	targetfloodprot.so clienttagdeny.so watch-backend.so \

--- a/src/modules/oper-tag.c
+++ b/src/modules/oper-tag.c
@@ -1,6 +1,6 @@
 /*
  *   IRC - Internet Relay Chat, src/modules/oper-tag.c
- *   (C) 2020 Syzop & The UnrealIRCd Team
+ *   (C) 2022 Valware & The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of
  *   the programmers.

--- a/src/modules/oper-tag.c
+++ b/src/modules/oper-tag.c
@@ -105,8 +105,6 @@ int oper_mtag_is_ok(Client *client, const char *name, const char *value)
 
 void mtag_add_oper(Client *client, MessageTag *recv_mtags, MessageTag **mtag_list, const char *signature)
 {
-	MessageTag *m;
-
 	if (IsUser(client) && IsOper(client))
 	{
 		MessageTag *m = find_mtag(recv_mtags, MTAG_OPER);
@@ -125,11 +123,9 @@ void mtag_add_oper(Client *client, MessageTag *recv_mtags, MessageTag **mtag_lis
 
 void mtag_add_oper_name(Client *client, MessageTag *recv_mtags, MessageTag **mtag_list, const char *signature)
 {
-	MessageTag *m;
-
 	if (IsUser(client) && IsOper(client))
 	{
-	  MessageTag *m = find_mtag(recv_mtags, MTAG_OPER_NAME);
+	 	MessageTag *m = find_mtag(recv_mtags, MTAG_OPER_NAME);
 		if (m)
 		{
 		  m = duplicate_mtag(m);
@@ -145,16 +141,13 @@ void mtag_add_oper_name(Client *client, MessageTag *recv_mtags, MessageTag **mta
 
 void mtag_add_oper_class(Client *client, MessageTag *recv_mtags, MessageTag **mtag_list, const char *signature)
 {
-	MessageTag *m;
-
 	if (IsUser(client) && IsOper(client))
 	{
 		MessageTag *m = find_mtag(recv_mtags, MTAG_OPER_CLASS);
 		if (m)
-		{
 			m = duplicate_mtag(m);
-		} else {
-			
+		else
+		{
 			m = safe_alloc(sizeof(MessageTag));
 			safe_strdup(m->name, MTAG_OPER_CLASS);
 			safe_strdup(m->value, moddata_client_get(client, "operclass"));

--- a/src/modules/oper-tag.c
+++ b/src/modules/oper-tag.c
@@ -163,14 +163,6 @@ void mtag_add_oper_class(Client *client, MessageTag *recv_mtags, MessageTag **mt
 	}
 }
 
-/** Outgoing filter for draft/oper message tag */
-int oper_name_mtag_should_send_to_client(Client *target)
-{
-	if (IsServer(target) || IsOper(target))
-		return 1;
-	return 0;
-}
-
 /** Outgoing filter for unrealircd.org/opername message tag */
 int oper_name_mtag_should_send_to_client(Client *target)
 {

--- a/src/modules/oper-tag.c
+++ b/src/modules/oper-tag.c
@@ -60,7 +60,6 @@ MOD_INIT()
 	memset(&mtag, 0, sizeof(mtag));
 	mtag.name = MTAG_OPER;
 	mtag.is_ok = oper_mtag_is_ok;
-	mtag.should_send_to_client = oper_mtag_should_send_to_client;
 	mtag.flags = MTAG_HANDLER_FLAGS_NO_CAP_NEEDED;
 	MessageTagHandlerAdd(modinfo->handle, &mtag);
 

--- a/src/modules/oper-tag.c
+++ b/src/modules/oper-tag.c
@@ -41,8 +41,6 @@ ModuleHeader MOD_HEADER
 	"unrealircd-6",
 	};
 
-/* Variables */
-long CAP_ACCOUNT_TAG = 0L;
 
 int oper_mtag_is_ok(Client *client, const char *name, const char *value);
 int oper_name_mtag_should_send_to_client(Client *target);

--- a/src/modules/oper-tag.c
+++ b/src/modules/oper-tag.c
@@ -1,0 +1,191 @@
+/*
+ *   IRC - Internet Relay Chat, src/modules/oper-tag.c
+ *   (C) 2020 Syzop & The UnrealIRCd Team
+ *
+ *   See file AUTHORS in IRC package for additional names of
+ *   the programmers.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 1, or (at your option)
+ *   any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "unrealircd.h"
+
+
+/*
+ * Due to limitations (cannot verify target in HOOKTYPE_NEW_MESSAGE where the mtag is generated) this implementation of
+ * draft/oper is split up into categories so we can better decide which information to send the target
+ * As the 'opername' and 'operclass' are not defined in any spec, I've prefixed them with unrealircd.org
+*/
+#define MTAG_OPER "draft/oper"
+#define MTAG_OPER_NAME "unrealircd.org/opername"
+#define MTAG_OPER_CLASS "unrealircd.org/operclass"
+
+ModuleHeader MOD_HEADER
+  = {
+	"oper-tag",
+	"5.0",
+	"oper message tag",
+	"UnrealIRCd Team",
+	"unrealircd-6",
+	};
+
+/* Variables */
+long CAP_ACCOUNT_TAG = 0L;
+
+int oper_mtag_is_ok(Client *client, const char *name, const char *value);
+int oper_name_mtag_should_send_to_client(Client *target);
+int oper_class_mtag_should_send_to_client(Client *target);
+void mtag_add_oper_name(Client *client, MessageTag *recv_mtags, MessageTag **mtag_list, const char *signature);
+void mtag_add_oper_class(Client *client, MessageTag *recv_mtags, MessageTag **mtag_list, const char *signature);
+void mtag_add_oper(Client *client, MessageTag *recv_mtags, MessageTag **mtag_list, const char *signature);
+
+MOD_INIT()
+{
+	MessageTagHandlerInfo mtag;
+
+	MARK_AS_OFFICIAL_MODULE(modinfo);
+
+	memset(&mtag, 0, sizeof(mtag));
+	mtag.name = MTAG_OPER;
+	mtag.is_ok = oper_mtag_is_ok;
+	mtag.should_send_to_client = oper_mtag_should_send_to_client;
+	mtag.flags = MTAG_HANDLER_FLAGS_NO_CAP_NEEDED;
+	MessageTagHandlerAdd(modinfo->handle, &mtag);
+
+	mtag.name = MTAG_OPER_NAME;
+	mtag.is_ok = oper_mtag_is_ok;
+	mtag.should_send_to_client = oper_name_mtag_should_send_to_client;
+	mtag.flags = MTAG_HANDLER_FLAGS_NO_CAP_NEEDED;
+	MessageTagHandlerAdd(modinfo->handle, &mtag);
+
+	mtag.name = MTAG_OPER_CLASS;
+	mtag.is_ok = oper_mtag_is_ok;
+	mtag.should_send_to_client = oper_class_mtag_should_send_to_client;
+	mtag.flags = MTAG_HANDLER_FLAGS_NO_CAP_NEEDED;
+	MessageTagHandlerAdd(modinfo->handle, &mtag);
+
+	HookAddVoid(modinfo->handle, HOOKTYPE_NEW_MESSAGE, 0, mtag_add_oper);
+	HookAddVoid(modinfo->handle, HOOKTYPE_NEW_MESSAGE, 0, mtag_add_oper_name);
+	HookAddVoid(modinfo->handle, HOOKTYPE_NEW_MESSAGE, 0, mtag_add_oper_class);
+
+	return MOD_SUCCESS;
+}
+
+MOD_LOAD()
+{
+	return MOD_SUCCESS;
+}
+
+MOD_UNLOAD()
+{
+	return MOD_SUCCESS;
+}
+
+/** This function verifies if the client sending
+ * 'oper-tag' is permitted to do so and uses a permitted
+ * syntax.
+ * We simply allow oper-tag ONLY from servers and with any syntax.
+ */
+int oper_mtag_is_ok(Client *client, const char *name, const char *value)
+{
+	if (IsServer(client))
+		return 1;
+
+	return 0;
+}
+
+void mtag_add_oper(Client *client, MessageTag *recv_mtags, MessageTag **mtag_list, const char *signature)
+{
+	MessageTag *m;
+
+	if (IsUser(client) && IsOper(client))
+	{
+		MessageTag *m = find_mtag(recv_mtags, MTAG_OPER);
+		if (m)
+		{
+			m = duplicate_mtag(m);
+		} else {
+			
+			m = safe_alloc(sizeof(MessageTag));
+			safe_strdup(m->name, MTAG_OPER);
+			m->value = NULL;
+		}
+		AddListItem(m, *mtag_list);
+	}
+}
+
+void mtag_add_oper_name(Client *client, MessageTag *recv_mtags, MessageTag **mtag_list, const char *signature)
+{
+	MessageTag *m;
+
+	if (IsUser(client) && IsOper(client))
+	{
+	  MessageTag *m = find_mtag(recv_mtags, MTAG_OPER_NAME);
+		if (m)
+		{
+		  m = duplicate_mtag(m);
+		} else {
+			
+			m = safe_alloc(sizeof(MessageTag));
+			safe_strdup(m->name, MTAG_OPER_NAME);
+			safe_strdup(m->value, client->user->operlogin);
+		}
+		AddListItem(m, *mtag_list);
+	}
+}
+
+void mtag_add_oper_class(Client *client, MessageTag *recv_mtags, MessageTag **mtag_list, const char *signature)
+{
+	MessageTag *m;
+
+	if (IsUser(client) && IsOper(client))
+	{
+		MessageTag *m = find_mtag(recv_mtags, MTAG_OPER_CLASS);
+		if (m)
+		{
+			m = duplicate_mtag(m);
+		} else {
+			
+			m = safe_alloc(sizeof(MessageTag));
+			safe_strdup(m->name, MTAG_OPER_CLASS);
+			safe_strdup(m->value, moddata_client_get(client, "operclass"));
+		}
+		AddListItem(m, *mtag_list);
+	}
+}
+
+/** Outgoing filter for draft/oper message tag */
+int oper_name_mtag_should_send_to_client(Client *target)
+{
+	if (IsServer(target) || IsOper(target))
+		return 1;
+	return 0;
+}
+
+/** Outgoing filter for unrealircd.org/opername message tag */
+int oper_name_mtag_should_send_to_client(Client *target)
+{
+	if (IsServer(target) || IsOper(target))
+		return 1;
+	return 0;
+}
+
+/** Outgoing filter for unrealircd.org/operclass message tag */
+int oper_class_mtag_should_send_to_client(Client *target)
+{
+	if (IsServer(target) || IsOper(target))
+		return 1;
+	return 0;
+}


### PR DESCRIPTION
The motivation for adding this is here: https://github.com/ircv3/ircv3-specifications/blob/1a508a26c051b68eccda9ffefffd819d975c2362/extensions/oper-tag.md

Because of some limitations I bumped into I've split it up into two (+1) separate tags:
- `draft/oper` (no value, shown to everyone)
- `unrealircd.org/opername` (value of operblock name, shown to opers)
- `unrealircd.org/operclass` (value of operclass, shown to opers)

The limitations are that, in a HOOKTYPE_NEW_MESSAGE, we cannot tell anything about the intended recipient while adding the tag, so we can't tell if we should show a value or not, which is why I've ended up splitting them up.