### PR TITLE
Update modules.default.conf

### DIFF
--- a/doc/conf/modules.default.conf
+++ b/doc/conf/modules.default.conf
@@ -259,6 +259,7 @@ loadmodule "json-log-tag"; /* unrealircd.org/json-log tag and CAP for ircops */
 loadmodule "targetfloodprot"; /* set::anti-flood::target-flood protection */
 loadmodule "watch-backend"; /* used by watch and other modules */
 loadmodule "geoip_base"; /* needed for ALL geoip functions */
+loadmodule "webserver"; /* needed for websocket connections */
 loadmodule "websocket_common"; /* helper functions for websocket (internal) */
 
 loadmodule "geoip_classic";


### PR DESCRIPTION
UnrealIRCd fails to boot when websockets are enabled, with the following error:
```
[info] Loading IRCd configuration..
[info] Testing IRCd configuration..
[error] The 'websocket' module requires the 'webserver' module to be loaded, otherwise websocket connections will not work!
[error] Add the following line to your config file: loadmodule "webserver";
[error] 1 errors encountered
[error] IRCd configuration failed to pass testing
[error] IRCd configuration failed to load
```
It's probably good to load the webserver module by default?