### PR TITLE
Bugfix: there was no check for the cap `server-time`

### DIFF
--- a/src/modules/server-time.c
+++ b/src/modules/server-time.c
@@ -77,7 +77,7 @@ MOD_UNLOAD()
  */
 int server_time_mtag_is_ok(Client *client, const char *name, const char *value)
 {
-	if (IsServer(client) && !BadPtr(value))
+	if (IsServer(client) && !BadPtr(value) && HasCapability(client,"server-time"))
 		return 1;
 
 	return 0;


### PR DESCRIPTION
This probably went unnoticed because of it being unusual NOT to request `server-time` if you requested `message-tags`  Patches https://bugs.unrealircd.org/view.php?id=6196