### PR TITLE
Make remote CONNECT logging use unreal_log() instead of SENDUMODE o.

### DIFF
--- a/src/modules/connect.c
+++ b/src/modules/connect.c
@@ -128,10 +128,10 @@ CMD_FUNC(cmd_connect)
 	/* Notify all operators about remote connect requests */
 	if (!MyUser(client))
 	{
-		sendto_server(NULL, 0, 0, NULL,
-		    ":%s SENDUMODE o :Remote CONNECT %s %s from %s",
-		    me.id, parv[1], parv[2] ? parv[2] : "",
-		    get_client_name(client, FALSE));
+		unreal_log(ULOG_INFO, "link", "REMOTE_LINK_REQUEST", client,
+		    "Remote CONNECT $servername $port from $client",
+		    log_data_string("servername", parv[1]),
+		    log_data_string("port", parv[2] ? parv[2] : ""));
 	}
 
 	connect_server(aconf, client, NULL);


### PR DESCRIPTION
This was excluded from be6bbbcc6b601b0528c6c1f40fdfe1062b77570f for some reason, maybe because it used sendto_server() instead of sendto_umode()/sendto_umode_global().