### PR TITLE
Channel QLines: Fix override checking logic

### DIFF
--- a/src/modules/join.c
+++ b/src/modules/join.c
@@ -492,7 +492,7 @@ void _do_join(Client *client, int parc, const char *parv[])
 					}
 				}
 			}
-			if (ValidatePermissionsForPath("immune:server-ban:deny-channel",client,NULL,NULL,NULL) && (tklban = find_qline(client, name, &ishold)))
+			if (!ValidatePermissionsForPath("immune:server-ban:deny-channel",client,NULL,NULL,NULL) && (tklban = find_qline(client, name, &ishold)))
 			{
 				sendnumeric(client, ERR_FORBIDDENCHANNEL, name, tklban->ptr.nameban->reason);
 				continue;


### PR DESCRIPTION
This fixes a check where a qline on a channel would only stop someone from joining if the person was an oper and they had immunity hehe