### PR TITLE
/helpop chmodes: Show channelmode +d

### DIFF
--- a/doc/conf/help/help.conf
+++ b/doc/conf/help/help.conf
@@ -161,7 +161,7 @@ help Chmodes {
 	"                       (For more info on extended bantypes, see /HELPOP EXTBANS)";
 	" c = Block messages containing mIRC color codes [o]";
 	" C = No CTCPs allowed in the channel [h]";
-	" d = Delayed users remaining after unsetting D [server]
+	" d = Delayed users remaining after unsetting D [server]";
 	" D = Delay showing joins until someone actually speaks [o]";
 	" e <nick!ident@host> = Overrides a ban for matching users [h]";
 	" f <floodparams> = Flood protection (for more info see /HELPOP CHMODEF) [o]";

--- a/doc/conf/help/help.conf
+++ b/doc/conf/help/help.conf
@@ -161,6 +161,7 @@ help Chmodes {
 	"                       (For more info on extended bantypes, see /HELPOP EXTBANS)";
 	" c = Block messages containing mIRC color codes [o]";
 	" C = No CTCPs allowed in the channel [h]";
+	" d = Delayed users remaining after unsetting D [server]
 	" D = Delay showing joins until someone actually speaks [o]";
 	" e <nick!ident@host> = Overrides a ban for matching users [h]";
 	" f <floodparams> = Flood protection (for more info see /HELPOP CHMODEF) [o]";
@@ -192,6 +193,7 @@ help Chmodes {
 	"     (This mode is set/unset by the server. Only if the channel is also +z)";
 	" -";
 	" [h] requires at least halfop, [o] requires at least chanop";
+	" [server] (un)settable only by the server";
 	" ==------------------------------oOo----------------------------==";
 }
 


### PR DESCRIPTION
Also since there are two criteria for server-only settable modes, add `[server]`  to the index/key below