### PR TITLE
chathistory: Advertize MSGREFTYPES ISUPPORT token

### DIFF
--- a/src/modules/chathistory.c
+++ b/src/modules/chathistory.c
@@ -48,6 +48,7 @@ MOD_INIT()
 MOD_LOAD()
 {
 	ISupportSetFmt(modinfo->handle, "CHATHISTORY", "%d", CHATHISTORY_LIMIT);
+	ISupportSetFmt(modinfo->handle, "MSGREFTYPES", "msgid,timestamp");
 	return MOD_SUCCESS;
 }
 


### PR DESCRIPTION
https://ircv3.net/specs/extensions/chathistory#isupport-tokens

The spec says they should be 'in order of decreasing preference'. As currently the only backend is in-memory, this doesn't matter so I picked `msgid` first (as it's less ambiguous); but this can be revisited later if/when adding a backend which is more efficient with timestamps.