### PR TITLE
Add 'history_delete' method to HistoryBackend

### DIFF
--- a/include/h.h
+++ b/include/h.h
@@ -1130,6 +1130,7 @@ extern void free_message_tags(MessageTag *m);
 extern int history_set_limit(const char *object, int max_lines, long max_t);
 extern int history_add(const char *object, MessageTag *mtags, const char *line);
 extern HistoryResult *history_request(const char *object, HistoryFilter *filter);
+extern int history_delete(const char *object, HistoryFilter *filter, int *rejected_deletes);
 extern int history_destroy(const char *object);
 extern int can_receive_history(Client *client);
 extern void history_send_result(Client *client, HistoryResult *r);

--- a/include/modules.h
+++ b/include/modules.h
@@ -572,6 +572,7 @@ struct HistoryFilter {
         char *msgid_a;			/**< First parameter of HFC_* (either this or timestamp_a) */
         char *timestamp_b;		/**< Second parameter of HFC_BETWEEN (either this or msgid_b) */
         char *msgid_b;			/**< Second parameter of HFC_BETWEEN (either this or timestamp_b) */
+        char *account;			/**< (For deletion only) if not NULL, reject deletion of messages not from this account */
         int limit;			/**< Maximum number of lines to return */
 };
 
@@ -599,6 +600,7 @@ struct HistoryBackend {
 	int (*history_set_limit)(const char *object, int max_lines, long max_time); /**< Impose a limit on a history object */
 	int (*history_add)(const char *object, MessageTag *mtags, const char *line); /**< Add to history */
 	HistoryResult *(*history_request)(const char *object, HistoryFilter *filter);  /**< Request history */
+	int (*history_delete)(const char *object, HistoryFilter *filter, int *rejected_deletes);  /**< Delete lines from the history. Returns the number of matching lines and sets rejected_deletes if not NULL */
 	int (*history_destroy)(const char *object);  /**< Destroy history of this object completely */
 	Module *owner;                                /**< Module introducing this */
 	char unloaded;                                /**< Internal flag to indicate module is being unloaded */
@@ -612,6 +614,7 @@ typedef struct {
 	int (*history_set_limit)(const char *object, int max_lines, long max_time);
 	int (*history_add)(const char *object, MessageTag *mtags, const char *line);
 	HistoryResult *(*history_request)(const char *object, HistoryFilter *filter);
+	int (*history_delete)(const char *object, HistoryFilter *filter, int *rejected_deletes);
 	int (*history_destroy)(const char *object);
 } HistoryBackendInfo;
 

--- a/src/modules/history_backend_null.c
+++ b/src/modules/history_backend_null.c
@@ -23,6 +23,7 @@ ModuleHeader MOD_HEADER
 int hbn_history_set_limit(const char *object, int max_lines, long max_time);
 int hbn_history_add(const char *object, MessageTag *mtags, const char *line);
 HistoryResult *hbn_history_request(const char *object, HistoryFilter *filter);
+int hbn_history_delete(const char *object, HistoryFilter *filter, int *rejected_deletes);
 int hbn_history_destroy(const char *object);
 
 MOD_INIT()
@@ -36,6 +37,7 @@ MOD_INIT()
 	hbi.history_set_limit = hbn_history_set_limit;
 	hbi.history_add = hbn_history_add;
 	hbi.history_request = hbn_history_request;
+	hbi.history_delete = hbn_history_delete;
 	hbi.history_destroy = hbn_history_destroy;
 	if (!HistoryBackendAdd(modinfo->handle, &hbi))
 		return MOD_FAILED;
@@ -66,6 +68,13 @@ HistoryResult *hbn_history_request(const char *object, HistoryFilter *filter)
 int hbn_history_set_limit(const char *object, int max_lines, long max_time)
 {
 	return 1;
+}
+
+int hbn_history_delete(const char *object, HistoryFilter *filter, int *rejected_deletes)
+{
+	if (rejected_deletes)
+		*rejected_deletes = 0;
+	return 0;
 }
 
 int hbn_history_destroy(const char *object)


### PR DESCRIPTION
This will allow modules to implement deletion of specific messages (unlike history_destroy, which removes the entire history of a channel)

For example, I wrote a third-party module for [IRCv3 draft/message-redaction](https://github.com/ircv3/ircv3-specifications/pull/524): https://github.com/progval/unrealircd-contrib/blob/redact/files/redact.c
I'll happily submit this module to Unreal itself if you're interested, after the spec stabilizes a bit.

This function offers nothing in Unreal itself; but I can write a stub module that allows opers to delete messages just as a demo, if you want some sort of built-in demo of the feature.