### PR TITLE
Update help.conf

### DIFF
--- a/doc/conf/help/help.conf
+++ b/doc/conf/help/help.conf
@@ -251,8 +251,11 @@ help ExtBans {
 	" These bantypes introduce new criteria which can be used:";
 	" =Letter-------Name---------------------------Explanation------------------------==";
 	"         |               | If a user is logged in to services with this account    ";
-	"    ~a   |   ~account    | name, then this ban will match.                         ";
-	"         |               | Example: +e ~account:Name                               ";
+	"         |               | name, then this ban will match.                         ";
+	"    ~a   |   ~account    | There are also two special bans: ~account:* matches all ";
+	"         |               | authenticated users and ~account:0 matches all          ";
+	"         |               | unauthenticated users.                                  ";
+	"         |               | Example: +e ~account:Name	+I ~account:Name            ";
 	"-----------------------------------------------------------------------------------";
 	"         |               | If the user is in this channel then they are unable to  ";
 	"         |               | join. A prefix can also be specified (+/%/@/&/~) which  ";


### PR DESCRIPTION
Specify the use of `~account:*` and `~account:0` on the usage of the `~account` extban on the `/helpop extbans` output.