### PR TITLE
Obtain GENCERTIFICATE value before writing config.settings

### DIFF
--- a/Config
+++ b/Config
@@ -148,36 +148,6 @@ cd "$UNREALCWD"
 if [ "$QUICK" != "1" ] ; then
 	if [ ! -f $CONFDIR/tls/server.cert.pem -a ! -f $CONFDIR/ssl/server.cert.pem ]; then
 		export OPENSSLPATH
-		TEST=""
-		while [ -z "$TEST" ] ; do
-			if [ "$GENCERTIFICATE" = "1" ] ; then
-				TEST="Yes"
-			else
-				TEST="No"
-			fi
-			echo ""
-			echo "UnrealIRCd requires a TLS certificate in order to work."
-			echo "Do you want to generate a TLS certificate for the IRCd?"
-			echo "Only answer No if you already have one."
-			echo $n "[$TEST] -> $c"
-			read cc
-			if [ -z "$cc" ] ; then
-			cc=$TEST
-			fi
-			case "$cc" in
-			[Yy]*)
-				GENCERTIFICATE="1"
-				;;
-			[Nn]*)
-				GENCERTIFICATE=""
-				;;
-			*)
-				echo ""
-				echo "You must enter either Yes or No"
-				TEST=""
-				;;
-			esac
-		done
 		if [ "$GENCERTIFICATE" = 1 ]; then
 			echo
 			echo "*******************************************************************************"
@@ -549,6 +519,37 @@ if [ "$SSLDIR" != "" -a "$SSLDIR" != "/usr" ]; then
 	echo "Press enter to continue with the rest of the questions, or CTRL+C to abort."
 	read cc
 fi
+
+TEST=""
+while [ -z "$TEST" ] ; do
+  if [ "$GENCERTIFICATE" = "1" ] ; then
+    TEST="Yes"
+  else
+    TEST="No"
+  fi
+  echo ""
+  echo "UnrealIRCd requires a TLS certificate in order to work."
+  echo "Do you want to generate a TLS certificate for the IRCd?"
+  echo "Only answer No if you already have one."
+  echo $n "[$TEST] -> $c"
+  read cc
+  if [ -z "$cc" ] ; then
+  cc=$TEST
+  fi
+  case "$cc" in
+  [Yy]*)
+    GENCERTIFICATE="1"
+    ;;
+  [Nn]*)
+    GENCERTIFICATE=""
+    ;;
+  *)
+    echo ""
+    echo "You must enter either Yes or No"
+    TEST=""
+    ;;
+  esac
+done
 
 TEST=""
 while [ -z "$TEST" ] ; do


### PR DESCRIPTION
Relates to https://bugs.unrealircd.org/view.php?id=6328

Solves the problem by moving the initial question about whether to generate a self-signed SSL cert to a point earlier in the process.

Actual generation of the cert (and associated property questions) remain at the end of the process.

The question now appears immediately after the "path to OpenSSL/LibreSSL" question, as it seemed like a reasonably logical place in the sequence for it to go.