### PR TITLE
sreply.c: Fix accidental truncation

### DIFF
--- a/src/modules/sreply.c
+++ b/src/modules/sreply.c
@@ -36,7 +36,7 @@ ModuleHeader MOD_HEADER
 /* This is called on module init, before Server Ready */
 MOD_INIT()
 {
-	CommandAdd(modinfo->handle, "SREPLY", cmd_sreply, MAXPARA, CMD_SERVER);
+	CommandAdd(modinfo->handle, "SREPLY", cmd_sreply, 4, CMD_SERVER);
 	MARK_AS_OFFICIAL_MODULE(modinfo);
 	return MOD_SUCCESS;
 }

--- a/src/modules/sreply.c
+++ b/src/modules/sreply.c
@@ -36,7 +36,7 @@ ModuleHeader MOD_HEADER
 /* This is called on module init, before Server Ready */
 MOD_INIT()
 {
-	CommandAdd(modinfo->handle, "SREPLY", cmd_sreply, 4, CMD_SERVER);
+	CommandAdd(modinfo->handle, "SREPLY", cmd_sreply, 3, CMD_SERVER);
 	MARK_AS_OFFICIAL_MODULE(modinfo);
 	return MOD_SUCCESS;
 }


### PR DESCRIPTION
This was causing the rest of the message to be cut off, where it should all be contained in `parv[3]`