### PR TITLE
Add Windows .gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ tls.rnd
 
 # Ignores for platform stuff
 .DS_Store
+[D|d]esktop.ini
 
 # Ignores for build artifacts
 *.so
@@ -43,6 +44,24 @@ tls.rnd
 src/ircd
 src/version.c
 src/include
+
+# Ignores for windows stuff
+## Binaries
+*.dll
+*.exe
+*.map
+*.pdb
+*.lib
+
+## Build artifacts
+*.obj
+*.exp
+*.ilk
+*.res
+##Other
+*.tmp
+UnrealIRCd.def*
+*.nativecodeanalysis.xml
 
 # Ignores for mac stuff
 ## Various settings


### PR DESCRIPTION
Windows builds produce files scattered around the source tree unlike *nix.
this should be a step forward a cleaner environment in git.
perhaps we should group the output into a Release/Debug folder?