### PR TITLE
Fix minor warning on conflicting types for Auth_Hash (AuthenticationType vs int)

### DIFF
--- a/include/h.h
+++ b/include/h.h
@@ -544,7 +544,7 @@ extern AuthenticationType Auth_FindType(const char *hash, const char *type);
 extern AuthConfig	*AuthBlockToAuthConfig(ConfigEntry *ce);
 extern void		Auth_FreeAuthConfig(AuthConfig *as);
 extern int		Auth_Check(Client *cptr, AuthConfig *as, const char *para);
-extern const char	*Auth_Hash(int type, const char *para);
+extern const char	*Auth_Hash(AuthenticationType type, const char *text);
 extern int   		Auth_CheckError(ConfigEntry *ce, int warn_on_plaintext);
 extern int              Auth_AutoDetectHashType(const char *hash);
 


### PR DESCRIPTION
I'm seeing the following very minor warning when building in -Werror due to a conflicting type.

auth.c:569:13: error: conflicting types for 'Auth_Hash' due to enum/integer mismatch; have 'const char *(AuthenticationType,  const char *)' [-Werror=enum-int-mismatch]
  569 | const char *Auth_Hash(AuthenticationType type, const char *text)
In file included from include/unrealircd.h:32, from auth.c:21: include/h.h:547:26: note: previous declaration of 'Auth_Hash' with type 'const char *(int,  const char *)'
  547 | extern const char       *Auth_Hash(int type, const char *para);