### PR TITLE
Add support for `draft/no-implicit-names`

### DIFF
--- a/doc/conf/modules.default.conf
+++ b/doc/conf/modules.default.conf
@@ -244,6 +244,7 @@ loadmodule "chathistory"; /* CHATHISTORY client command, 005 and a CAP (draft) *
 loadmodule "monitor"; /* MONITOR command with functionality similar to WATCH */
 loadmodule "extended-monitor"; /* add away status, gecos and userhost changes to MONITOR (draft) */
 loadmodule "standard-replies"; /* Standard Replies */
+loadmodule "no-implicit-names-cap"; /* Opt out of receiving implicit /NAMES when joining a channel */
 
 
 /*** RPC modules ***

--- a/src/api-event.c
+++ b/src/api-event.c
@@ -1,5 +1,5 @@
 /************************************************************************
- *   IRC - Internet Relay Chat, api-event.c
+ *   IRC - Internet Relay Chat, src/api-event.c
  *   (C) 2001- Carsten Munk (Techie/Stskeeps) <stskeeps@tspre.org>
  *   and the UnrealIRCd team
  *

--- a/src/api-extban.c
+++ b/src/api-extban.c
@@ -1,5 +1,5 @@
 /************************************************************************
- *   IRC - Internet Relay Chat, api-extban.c
+ *   IRC - Internet Relay Chat, src/api-extban.c
  *   (C) 2003 Bram Matthys (Syzop) and the UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/api-messagetag.c
+++ b/src/api-messagetag.c
@@ -1,5 +1,5 @@
 /************************************************************************
- *   UnrealIRCd - Unreal Internet Relay Chat Daemon - src/api-mtag.c
+ *   UnrealIRCd - Unreal Internet Relay Chat Daemon - src/api-messagetag.c
  *   (c) 2019- Bram Matthys and The UnrealIRCd team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/conf_preprocessor.c
+++ b/src/conf_preprocessor.c
@@ -1,4 +1,6 @@
-/* UnrealIRCd configuration preprocessor
+/* 
+ * IRC - Internet Relay Chat, src/conf_preprocessor.c
+ * UnrealIRCd configuration preprocessor
  * (C) Copyright 2019 Bram Matthys ("Syzop") and the UnrealIRCd team
  * License: GPLv2 or later
  *

--- a/src/crashreport.c
+++ b/src/crashreport.c
@@ -1,4 +1,6 @@
-/* UnrealIRCd crash reporter code.
+/*  
+ * IRC - Internet Relay Chat, src/crashreport.c
+ * UnrealIRCd crash reporter code.
  * (C) Copyright 2015-2019 Bram Matthys ("Syzop") and the UnrealIRCd Team.
  * License: GPLv2 or later
  */

--- a/src/crypt_blowfish.c
+++ b/src/crypt_blowfish.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/crypt_blowfish.c
  * The crypt_blowfish homepage is:
  *
  *	http://www.openwall.com/crypt/

--- a/src/log.c
+++ b/src/log.c
@@ -1,5 +1,5 @@
 /************************************************************************
- * IRC - Internet Relay Chat, src/api-channelmode.c
+ * IRC - Internet Relay Chat, src/log.c
  * (C) 2021 Bram Matthys (Syzop) and the UnrealIRCd Team
  *
  * See file AUTHORS in IRC package for additional names of

--- a/src/mempool.c
+++ b/src/mempool.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/mempool.c
  * Copyright (c) 2007-2012, The Tor Project, Inc.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/modulemanager.c
+++ b/src/modulemanager.c
@@ -1,4 +1,6 @@
-/* UnrealIRCd module manager.
+/*  
+ * IRC - Internet Relay Chat, src/modulemanager.c
+ * UnrealIRCd module manager.
  * (C) Copyright 2019 Bram Matthys ("Syzop") and the UnrealIRCd Team.
  * License: GPLv2 or later
  * See https://www.unrealircd.org/docs/Module_manager for user documentation.

--- a/src/modules/Makefile.in
+++ b/src/modules/Makefile.in
@@ -85,6 +85,7 @@ MODULES= \
 	real-quit-reason.so \
 	spamreport.so crule.so \
 	central-api.so central-blocklist.so \
+ 	no-implicit-names-cap.so \
 	$(GEOIP_CLASSIC_OBJECTS) $(GEOIP_MAXMIND_OBJECTS)
 
 MODULEFLAGS=@MODULEFLAGS@

--- a/src/modules/addmotd.c
+++ b/src/modules/addmotd.c
@@ -1,5 +1,5 @@
 /*
- *   IRC - Internet Relay Chat, src/modules/out.c
+ *   IRC - Internet Relay Chat, src/modules/addmotd.c
  *   (C) 2004 The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/modules/admin.c
+++ b/src/modules/admin.c
@@ -1,5 +1,5 @@
 /*
- *   IRC - Internet Relay Chat, src/modules/out.c
+ *   IRC - Internet Relay Chat, src/modules/admin.c
  *   (C) 2004 The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/modules/chanmodes/censor.c
+++ b/src/modules/chanmodes/censor.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/censor.c
  * Channel Mode +G
  * (C) Copyright 2005-current Bram Matthys and The UnrealIRCd team.
  */

--- a/src/modules/chanmodes/chanadmin.c
+++ b/src/modules/chanmodes/chanadmin.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/chanadmin.c
  * Channel Mode +a
  * (C) Copyright 2021 Syzop and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/chanop.c
+++ b/src/modules/chanmodes/chanop.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/chanop.c
  * Channel Mode +o
  * (C) Copyright 2021 Syzop and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/chanowner.c
+++ b/src/modules/chanmodes/chanowner.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/chanowner.c
  * Channel Mode +q
  * (C) Copyright 2021 Syzop and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/delayjoin.c
+++ b/src/modules/chanmodes/delayjoin.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/delayjoin.c
  * Channel mode +D/+d: delayed join
  * except from opers, U-lines and servers.
  * Copyright 2014 Travis Mcarthur <Heero> and UnrealIRCd Team

--- a/src/modules/chanmodes/floodprot.c
+++ b/src/modules/chanmodes/floodprot.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/floodprot.c
  * Channel Mode +f and +F
  * (C) Copyright 2019-.. Syzop and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/halfop.c
+++ b/src/modules/chanmodes/halfop.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/halfop.c
  * Channel Mode +h
  * (C) Copyright 2021 Syzop and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/history.c
+++ b/src/modules/chanmodes/history.c
@@ -1,5 +1,6 @@
-/*
- * modules/chanmodes/history - Channel History
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/history.c
+ * Channel History
  * (C) Copyright 2009-2019 Bram Matthys (Syzop) and the UnrealIRCd team
  * License: GPLv2 or later
  */

--- a/src/modules/chanmodes/inviteonly.c
+++ b/src/modules/chanmodes/inviteonly.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/inviteonly.c
  * Channel Mode +i
  * (C) Copyright 2021 Syzop and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/isregistered.c
+++ b/src/modules/chanmodes/isregistered.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/isregistered.c
  * Channel Mode +r
  * (C) Copyright 2021 Syzop and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/issecure.c
+++ b/src/modules/chanmodes/issecure.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/issecure.c
  * Channel Is Secure UnrealIRCd module (Channel Mode +Z)
  * (C) Copyright 2010-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/key.c
+++ b/src/modules/chanmodes/key.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/key.c
  * Channel Mode +k
  * (C) Copyright 2021 Syzop and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/limit.c
+++ b/src/modules/chanmodes/limit.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/limit.c
  * Channel Mode +l
  * (C) Copyright 2021 Syzop and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/link.c
+++ b/src/modules/chanmodes/link.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/link.c
  * Robust channel forwarding system
  * (C) Copyright 2019 Syzop, Gottem and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/moderated.c
+++ b/src/modules/chanmodes/moderated.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/moderated.c
  * Channel Mode +m
  * (C) Copyright 2021 Syzop and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/nocolor.c
+++ b/src/modules/chanmodes/nocolor.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/nocolor.c
  * Block Color UnrealIRCd Module (Channel Mode +c)
  * (C) Copyright 2000-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/noctcp.c
+++ b/src/modules/chanmodes/noctcp.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/noctcp.c
  * Block CTCP UnrealIRCd Module (Channel Mode +C)
  * (C) Copyright 2000-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/noexternalmsgs.c
+++ b/src/modules/chanmodes/noexternalmsgs.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/noexternalmsgs.c
  * Channel Mode +n
  * (C) Copyright 2021 Syzop and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/noinvite.c
+++ b/src/modules/chanmodes/noinvite.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/noinvite.c
  * Disallow invites UnrealIRCd Module (Channel Mode +V)
  * (C) Copyright 2014 Travis McArthur (Heero) and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/nokick.c
+++ b/src/modules/chanmodes/nokick.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/nokick.c
  * No kicks in channel UnrealIRCd Module (Channel Mode +Q)
  * (C) Copyright 2014 Travis McArthur (Heero) and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/noknock.c
+++ b/src/modules/chanmodes/noknock.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/noknock.c
  * Disallow knocks UnrealIRCd Module (Channel Mode +K)
  * (C) Copyright 2014 Travis McArthur (Heero) and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/nonickchange.c
+++ b/src/modules/chanmodes/nonickchange.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/nonickchange.c
  * No nick changes in channel UnrealIRCd Module (Channel Mode +N)
  * (C) Copyright 2014 Travis McArthur (Heero) and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/nonotice.c
+++ b/src/modules/chanmodes/nonotice.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/nonotice.c
  * Disallow notices in channel UnrealIRCd Module (Channel Mode +T)
  * (C) Copyright 2014 Travis McArthur (Heero) and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/operonly.c
+++ b/src/modules/chanmodes/operonly.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/operonly.c
  * Disallow knocks UnrealIRCd Module (Channel Mode +K)
  * (C) Copyright 2014 Travis McArthur (Heero) and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/private.c
+++ b/src/modules/chanmodes/private.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/private.c
  * Channel Mode +p
  * (C) Copyright 2021 Syzop and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/regonly.c
+++ b/src/modules/chanmodes/regonly.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/regonly.c
  * Registered users only UnrealIRCd Module (Channel Mode +R)
  * (C) Copyright 2014 Travis McArthur (Heero) and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/regonlyspeak.c
+++ b/src/modules/chanmodes/regonlyspeak.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/regonlyspeak.c
  * Only registered users can speak UnrealIRCd Module (Channel Mode +M)
  * (C) Copyright 2014 Travis McArthur (Heero) and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/secret.c
+++ b/src/modules/chanmodes/secret.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/secret.c
  * Channel Mode +s
  * (C) Copyright 2021 Syzop and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/secureonly.c
+++ b/src/modules/chanmodes/secureonly.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/secureonly.c
  * Only allow secure users to join UnrealIRCd Module (Channel Mode +z)
  * (C) Copyright 2014 Travis McArthur (Heero) and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/stripcolor.c
+++ b/src/modules/chanmodes/stripcolor.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/stripcolor.c
  * Strip Color UnrealIRCd Module (Channel Mode +S)
  * (C) Copyright 2000-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/topiclimit.c
+++ b/src/modules/chanmodes/topiclimit.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/topiclimit.c
  * Channel Mode +t
  * (C) Copyright 2021 Syzop and the UnrealIRCd team
  *

--- a/src/modules/chanmodes/voice.c
+++ b/src/modules/chanmodes/voice.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/chanmodes/voice.c
  * Channel Mode +v
  * (C) Copyright 2021 Syzop and the UnrealIRCd team
  *

--- a/src/modules/clienttagdeny.c
+++ b/src/modules/clienttagdeny.c
@@ -1,5 +1,5 @@
 /*
- *   IRC - Internet Relay Chat, src/modules/echo-message.c
+ *   IRC - Internet Relay Chat, src/modules/client-tag-deny.c
  *   (C) 2020 k4be for The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/modules/close.c
+++ b/src/modules/close.c
@@ -1,5 +1,5 @@
 /*
- *   IRC - Internet Relay Chat, src/modules/out.c
+ *   IRC - Internet Relay Chat, src/modules/close.c
  *   (C) 2004 The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/modules/connect.c
+++ b/src/modules/connect.c
@@ -1,5 +1,5 @@
 /*
- *   IRC - Internet Relay Chat, src/modules/out.c
+ *   IRC - Internet Relay Chat, src/modules/connect.c
  *   (C) 2004 The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/modules/dccallow.c
+++ b/src/modules/dccallow.c
@@ -1,5 +1,5 @@
 /*
- *   IRC - Internet Relay Chat, src/modules/m_dccallow
+ *   IRC - Internet Relay Chat, src/modules/dccallow
  *   (C) 2004 The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/modules/dccallow.c
+++ b/src/modules/dccallow.c
@@ -1,5 +1,5 @@
 /*
- *   IRC - Internet Relay Chat, src/modules/dccallow
+ *   IRC - Internet Relay Chat, src/modules/dccallow.c
  *   (C) 2004 The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/modules/eos.c
+++ b/src/modules/eos.c
@@ -1,5 +1,5 @@
 /*
- *   IRC - Internet Relay Chat, src/modules/out.c
+ *   IRC - Internet Relay Chat, src/modules/eos.c
  *   (C) 2004 The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/modules/extbans/account.c
+++ b/src/modules/extbans/account.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/extbans/account.c
  * Extended ban to ban/exempt by services account (~b ~a:accountname)
  * (C) Copyright 2011-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/extbans/certfp.c
+++ b/src/modules/extbans/certfp.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/extbans/certfp.c
  * Extended ban to ban/exempt by certificate fingerprint (+b ~S:certfp)
  * (C) Copyright 2015 The UnrealIRCd Team
  *

--- a/src/modules/extbans/country.c
+++ b/src/modules/extbans/country.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/extbans/country.c
  * Extended ban to ban/exempt by country/geoip info (+b ~country:UK)
  * (C) Copyright 2021 The UnrealIRCd Team
  *

--- a/src/modules/extbans/flood.c
+++ b/src/modules/extbans/flood.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/extbans/flood.c
  * Extended ban to exempt from +f/+F checking.
  * Eg: +e ~flood:*:~account:TrustedBot
  * (C) Copyright 2023-.. Bram Matthys (Syzop) and the UnrealIRCd team

--- a/src/modules/extbans/inchannel.c
+++ b/src/modules/extbans/inchannel.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/extbans/inchannel.c
  * Extended ban: "in channel?" (+b ~c:#chan)
  * (C) Copyright 2003-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/extbans/join.c
+++ b/src/modules/extbans/join.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/extbans/join.c
  * Extended ban that affects JOIN only (+b ~j)
  * (C) Copyright 2003-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/extbans/msgbypass.c
+++ b/src/modules/extbans/msgbypass.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/extbans/msgbypass.c
  * Extended ban that allows user to bypass message restrictions
  * (C) Copyright 2017-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/extbans/nickchange.c
+++ b/src/modules/extbans/nickchange.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/extbans/nickchange.c
  * Extended ban that affects nick-changes only (+b ~n)
  * (C) Copyright 2003-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/extbans/operclass.c
+++ b/src/modules/extbans/operclass.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/extbans/operclass.c
  * Extended ban type: ban (or rather: exempt or invex) an operclass.
  * (C) Copyright 2003-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/extbans/partmsg.c
+++ b/src/modules/extbans/partmsg.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/extbans/partmsg.c
  * Hide Part/Quit message extended ban (+b ~p:nick!user@host)
  * (C) Copyright i <info@servx.org> and the UnrealIRCd team
  *

--- a/src/modules/extbans/quiet.c
+++ b/src/modules/extbans/quiet.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/extbans/quiet.c
  * Extended ban that affects messages/notices only (+b ~q)
  * (C) Copyright 2003-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/extbans/realname.c
+++ b/src/modules/extbans/realname.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/extbans/realname.c
  * Extended ban to ban based on real name / gecos field (+b ~r)
  * (C) Copyright 2003-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/extbans/securitygroup.c
+++ b/src/modules/extbans/securitygroup.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/extbans/securitygroup.c
  * Extended ban to ban based on security groups such as "unknown-users"
  * (C) Copyright 2020 Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/extbans/textban.c
+++ b/src/modules/extbans/textban.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/extbans/textban.c
  * Text ban. (C) Copyright 2004-2016 Bram Matthys.
  * 
  * This program is free software; you can redistribute it and/or

--- a/src/modules/extbans/timedban.c
+++ b/src/modules/extbans/timedban.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/extbans/timedban.c
  * timedban - Timed bans that are automatically unset.
  * (C) Copyright 2009-2017 Bram Matthys (Syzop) and the UnrealIRCd team.
  * License: GPLv2 or later

--- a/src/modules/globops.c
+++ b/src/modules/globops.c
@@ -1,5 +1,5 @@
 /*
- *   IRC - Internet Relay Chat, src/modules/out.c
+ *   IRC - Internet Relay Chat, src/modules/globops.c
  *   (C) 2004 The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/modules/help.c
+++ b/src/modules/help.c
@@ -1,5 +1,5 @@
 /*
- *   IRC - Internet Relay Chat, src/modules/out.c
+ *   IRC - Internet Relay Chat, src/modules/help.c
  *   (C) 2004 The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/modules/issued-by-tag.c
+++ b/src/modules/issued-by-tag.c
@@ -1,4 +1,4 @@
-/*
+/* src/modules/issued-by-tag.c
  * unrealircd.org/issued-by message tag (server only)
  * Shows who or what actually issued the command.
  * (C) Copyright 2023-.. Syzop and The UnrealIRCd Team

--- a/src/modules/join.c
+++ b/src/modules/join.c
@@ -270,7 +270,8 @@ void _join_channel(Channel *channel, Client *client, MessageTag *recv_mtags, con
 		parv[0] = NULL;
 		parv[1] = channel->name;
 		parv[2] = NULL;
-		do_cmd(client, NULL, "NAMES", 2, parv);
+		if (!HasCapability(client,"draft/no-implicit-names") && !HasCapability(client, "no-implicit-names"))
+			do_cmd(client, NULL, "NAMES", 2, parv);;
 
 		unreal_log(ULOG_INFO, "join", "LOCAL_CLIENT_JOIN", client,
 			   "User $client joined $channel",

--- a/src/modules/json-log-tag.c
+++ b/src/modules/json-log-tag.c
@@ -1,5 +1,5 @@
 /*
- *   IRC - Internet Relay Chat, src/modules/monitor.c
+ *   IRC - Internet Relay Chat, src/modules/json-log-tag.c
  *   (C) 2021 Bram Matthys and The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/modules/links.c
+++ b/src/modules/links.c
@@ -1,5 +1,5 @@
 /*
- *   IRC - Internet Relay Chat, src/modules/out.c
+ *   IRC - Internet Relay Chat, src/modules/links.c
  *   (C) 2004 The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/modules/locops.c
+++ b/src/modules/locops.c
@@ -1,5 +1,5 @@
 /*
- *   IRC - Internet Relay Chat, src/modules/out.c
+ *   IRC - Internet Relay Chat, src/modules/locops.c
  *   (C) 2004 The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/modules/map.c
+++ b/src/modules/map.c
@@ -1,5 +1,5 @@
 /*
- *   IRC - Internet Relay Chat, src/modules/out.c
+ *   IRC - Internet Relay Chat, src/modules/map.c
  *   (C) 2004 The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/modules/netinfo.c
+++ b/src/modules/netinfo.c
@@ -1,5 +1,5 @@
 /*
- *   IRC - Internet Relay Chat, src/modules/out.c
+ *   IRC - Internet Relay Chat, src/modules/netinfo.c
  *   (C) 2004 The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/modules/no-implicit-names-cap.c
+++ b/src/modules/no-implicit-names-cap.c
@@ -1,0 +1,67 @@
+/*
+ *   Unreal Internet Relay Chat Daemon, src/modules/no-implicit-names-cap.c
+ *   (C) 2023 Valware and the UnrealIRCd Team
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 1, or (at your option)
+ *   any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "unrealircd.h"
+
+ModuleHeader MOD_HEADER
+  = {
+	"no-implicit-names-cap",
+	"1.0",
+	"Opt out of receiving an implicit NAMES list on JOIN", 
+	"UnrealIRCd Team",
+	"unrealircd-6",
+};
+
+#define NO_IMPLICIT_NAMES_CAP_DRAFT "draft/no-implicit-names"
+#define NO_IMPLICIT_NAMES_CAP "no-implicit-names"
+
+long CAP_NO_IMPLICIT_NAMES_DRAFT = 0L;
+long CAP_NO_IMPLICIT_NAMES = 0L;
+
+MOD_INIT()
+{
+	/** We only add the draft version for now */
+	ClientCapabilityInfo cap;
+	memset(&cap, 0, sizeof(cap));
+	cap.name = NO_IMPLICIT_NAMES_CAP_DRAFT;
+	if (!ClientCapabilityAdd(modinfo->handle, &cap, &CAP_NO_IMPLICIT_NAMES_DRAFT))
+	{
+		return MOD_FAILED;
+	}
+
+	/** This is for the future :D */
+	/**
+	memset(&cap, 0, sizeof(cap));
+	cap.name = NO_IMPLICIT_NAMES_CAP;
+	ClientCapabilityAdd(modinfo->handle, &cap, &CAP_NO_IMPLICIT_NAMES);
+	*/
+
+	return MOD_SUCCESS;
+}
+
+MOD_LOAD()
+{
+	return MOD_SUCCESS;
+}
+
+MOD_UNLOAD()
+{
+	return MOD_SUCCESS;
+}
+

--- a/src/modules/nocodes.c
+++ b/src/modules/nocodes.c
@@ -1,4 +1,4 @@
-/*
+/* IRC, Internet Relay Chat - src/modules/nocodes.c
  * "No Codes", a very simple (but often requested) module written by Syzop.
  * This module will strip messages with bold/underline/reverse if chanmode
  * +S is set, and block them if +c is set.

--- a/src/modules/operinfo.c
+++ b/src/modules/operinfo.c
@@ -1,4 +1,4 @@
-/*
+/* IRC - Internet Relay Chat, src/modules/operinfo.c
  * Store oper login in ModData, used by WHOIS and for auditting purposes.
  * (C) Copyright 2021-.. Syzop and The UnrealIRCd Team
  * License: GPLv2 or later

--- a/src/modules/real-quit-reason.c
+++ b/src/modules/real-quit-reason.c
@@ -1,4 +1,4 @@
-/*
+/* IRC - Internet Relay Chat, src/modules/real-quit-reason.c
  * unrealircd.org/real-quit-reason message tag (server only)
  * This is really server-only, it does not traverse to any clients.
  * (C) Copyright 2023-.. Syzop and The UnrealIRCd Team

--- a/src/modules/reputation.c
+++ b/src/modules/reputation.c
@@ -1,4 +1,4 @@
-/*
+/* IRC - Internet Relay Chat, src/modules/reputation.c
  * reputation - Provides a scoring system for "known users".
  * (C) Copyright 2015-2019 Bram Matthys (Syzop) and the UnrealIRCd team.
  * License: GPLv2 or later

--- a/src/modules/require-module.c
+++ b/src/modules/require-module.c
@@ -1,4 +1,4 @@
-/*
+/* IRC - Internet Relay Chat, src/modules/require-module.c
  * Check for modules that are required across the network, as well as modules
  * that *aren't* even allowed (deny/require module { } blocks)
  * (C) Copyright 2019 Gottem and the UnrealIRCd team

--- a/src/modules/restrict-commands.c
+++ b/src/modules/restrict-commands.c
@@ -1,4 +1,4 @@
-/*
+/* IRC - Internet Relay Chat, src/modules/restrict-commands.c
  * Restrict specific commands unless certain conditions have been met
  * (C) Copyright 2019 Gottem and the UnrealIRCd team
  *

--- a/src/modules/rmtkl.c
+++ b/src/modules/rmtkl.c
@@ -1,4 +1,4 @@
-/*
+/* IRC - Internet Relay Chat, src/modules/rmtkl.c
  * Easily remove *-Lines in bulk
  * (C) Copyright 2019 Gottem and the UnrealIRCd team
  *

--- a/src/modules/rpc/channel.c
+++ b/src/modules/rpc/channel.c
@@ -1,4 +1,6 @@
-/* channel.* RPC calls
+/* 
+ * IRC - Internet Relay Chat, src/modules/rpc/channel.c
+ * channel.* RPC calls
  * (C) Copyright 2022-.. Bram Matthys (Syzop) and the UnrealIRCd team
  * License: GPLv2 or later
  */

--- a/src/modules/rpc/log.c
+++ b/src/modules/rpc/log.c
@@ -1,4 +1,6 @@
-/* log.* RPC calls
+/*  
+ * IRC - Internet Relay Chat, src/modules/rpc/log.c
+ * log.* RPC calls
  * (C) Copyright 2023-.. Bram Matthys (Syzop) and the UnrealIRCd team
  * License: GPLv2 or later
  */

--- a/src/modules/rpc/name_ban.c
+++ b/src/modules/rpc/name_ban.c
@@ -1,4 +1,6 @@
-/* name_ban.* RPC calls
+/*  
+ * IRC - Internet Relay Chat, src/modules/rpc/name_ban.c
+ * name_ban.* RPC calls
  * (C) Copyright 2022-.. Bram Matthys (Syzop) and the UnrealIRCd team
  * License: GPLv2 or later
  */

--- a/src/modules/rpc/rpc.c
+++ b/src/modules/rpc/rpc.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/rpc/rpc.c
  * RPC module - for remote management of UnrealIRCd
  * (C)Copyright 2022 Bram Matthys and the UnrealIRCd team
  * License: GPLv2 or later

--- a/src/modules/rpc/server.c
+++ b/src/modules/rpc/server.c
@@ -1,4 +1,6 @@
-/* server.* RPC calls
+/*  
+ * IRC - Internet Relay Chat, src/modules/rpc/server.c
+ * server.* RPC calls
  * (C) Copyright 2022-.. Bram Matthys (Syzop) and the UnrealIRCd team
  * License: GPLv2 or later
  */

--- a/src/modules/rpc/server_ban.c
+++ b/src/modules/rpc/server_ban.c
@@ -1,4 +1,6 @@
-/* server_ban.* RPC calls
+/*  
+ * IRC - Internet Relay Chat, src/modules/rpc/server_ban.c
+ * server_ban.* RPC calls
  * (C) Copyright 2022-.. Bram Matthys (Syzop) and the UnrealIRCd team
  * License: GPLv2 or later
  */

--- a/src/modules/rpc/server_ban_exception.c
+++ b/src/modules/rpc/server_ban_exception.c
@@ -1,4 +1,6 @@
-/* server_ban_exception.* RPC calls
+/*  
+ * IRC - Internet Relay Chat, src/modules/rpc/server_ban_exception.c
+ * server_ban_exception.* RPC calls
  * (C) Copyright 2022-.. Bram Matthys (Syzop) and the UnrealIRCd team
  * License: GPLv2 or later
  */

--- a/src/modules/rpc/spamfilter.c
+++ b/src/modules/rpc/spamfilter.c
@@ -1,4 +1,6 @@
-/* spamfilter.* RPC calls
+/*  
+ * IRC - Internet Relay Chat, src/modules/rpc/spamfilter.c
+ * spamfilter.* RPC calls
  * (C) Copyright 2022-.. Bram Matthys (Syzop) and the UnrealIRCd team
  * License: GPLv2 or later
  */

--- a/src/modules/rpc/stats.c
+++ b/src/modules/rpc/stats.c
@@ -1,4 +1,6 @@
-/* stats.* RPC calls
+/*  
+ * IRC - Internet Relay Chat, src/modules/rpc/stats.c
+ * stats.* RPC calls
  * (C) Copyright 2022-.. Bram Matthys (Syzop) and the UnrealIRCd team
  * License: GPLv2 or later
  */

--- a/src/modules/rpc/user.c
+++ b/src/modules/rpc/user.c
@@ -1,4 +1,6 @@
-/* user.* RPC calls
+/*  
+ * IRC - Internet Relay Chat, src/modules/rpc/user.c
+ * user.* RPC calls
  * (C) Copyright 2022-.. Bram Matthys (Syzop) and the UnrealIRCd team
  * License: GPLv2 or later
  */

--- a/src/modules/rpc/whowas.c
+++ b/src/modules/rpc/whowas.c
@@ -1,4 +1,6 @@
-/* whowas.* RPC calls
+/*  
+ * IRC - Internet Relay Chat, src/modules/rpc/whowas.c
+ * whowas.* RPC calls
  * (C) Copyright 2023-.. Bram Matthys (Syzop) and the UnrealIRCd team
  * License: GPLv2 or later
  */

--- a/src/modules/rules.c
+++ b/src/modules/rules.c
@@ -1,5 +1,5 @@
 /*
- *   IRC - Internet Relay Chat, src/modules/out.c
+ *   IRC - Internet Relay Chat, src/modules/rules.c
  *   (C) 2004 The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/modules/sinfo.c
+++ b/src/modules/sinfo.c
@@ -1,4 +1,5 @@
 /*
+ *  IRC - Internet Relay Chat, src/modules/sinfo.c
  * cmd_sinfo - Server information
  * (C) Copyright 2019 Bram Matthys (Syzop) and the UnrealIRCd team.
  * License: GPLv2 or later

--- a/src/modules/slog.c
+++ b/src/modules/slog.c
@@ -1,5 +1,5 @@
 /*
- *   IRC - Internet Relay Chat, src/modules/monitor.c
+ *   IRC - Internet Relay Chat, src/modules/slog.c
  *   (C) 2021 Bram Matthys and The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/modules/staff.c
+++ b/src/modules/staff.c
@@ -1,4 +1,5 @@
 /*
+ *   IRC - Internet Relay Chat, src/modules/staff.c
  *   cmd_staff: Displays a file(/URL) when the /STAFF command is used.
  *   (C) Copyright 2004-2016 Syzop <syzop@vulnscan.org>
  *   (C) Copyright 2003-2004 AngryWolf <angrywolf@flashmail.com>

--- a/src/modules/targetfloodprot.c
+++ b/src/modules/targetfloodprot.c
@@ -1,4 +1,6 @@
-/* Target flood protection
+/*
+ * IRC - Internet Relay Chat, src/modules/targetfloodprot.c
+ * Target flood protection
  * (C)Copyright 2020 Bram Matthys and the UnrealIRCd team
  * License: GPLv2 or later
  */

--- a/src/modules/tkldb.c
+++ b/src/modules/tkldb.c
@@ -1,4 +1,5 @@
 /*
+ * IRC - Internet Relay Chat, src/modules/tkldb.c
  * Stores active *-Lines (G-Lines etc) inside a .db file for persistency
  * (C) Copyright 2019 Gottem and the UnrealIRCd team
  *

--- a/src/modules/tls_antidos.c
+++ b/src/modules/tls_antidos.c
@@ -1,4 +1,5 @@
 /*
+ * IRC - Internet Relay Chat, src/modules/tls_antidos.c
  * TLS Anti DoS module
  * This protects against TLS renegotiation attacks while still allowing us
  * to leave renegotiation on with all it's security benefits.

--- a/src/modules/tls_cipher.c
+++ b/src/modules/tls_cipher.c
@@ -1,4 +1,5 @@
 /*
+ * IRC - Internet Relay Chat, src/modules/tls_cipher.c
  * Store TLS cipher in ModData
  * (C) Copyright 2021-.. Syzop and The UnrealIRCd Team
  * License: GPLv2 or later

--- a/src/modules/unreal_server_compat.c
+++ b/src/modules/unreal_server_compat.c
@@ -1,4 +1,5 @@
 /*
+ * IRC - Internet Relay Chat, src/modules/unreal_server_compat.c
  * unreal_server_compat - Compatibility with pre-U6 servers
  * (C) Copyright 2016-2021 Bram Matthys (Syzop)
  * License: GPLv2 or later

--- a/src/modules/usermodes/bot.c
+++ b/src/modules/usermodes/bot.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/usermodes/bot.c
  * Bot user mode (User mode +B)
  * (C) Copyright 2000-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/usermodes/censor.c
+++ b/src/modules/usermodes/censor.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/usermodes/censor.c
  * User Mode +G
  * (C) Copyright 2005-current Bram Matthys and The UnrealIRCd team.
  */

--- a/src/modules/usermodes/noctcp.c
+++ b/src/modules/usermodes/noctcp.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/usermodes/noctcp.c
  * Block user-to-user CTCP UnrealIRCd Module (User Mode +T)
  * (C) Copyright 2000-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/usermodes/nokick.c
+++ b/src/modules/usermodes/nokick.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/usermodes/nokick.c
  * Prevents you from being kicked (User mode +q)
  * (C) Copyright 2000-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/usermodes/privacy.c
+++ b/src/modules/usermodes/privacy.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/usermodes/privacy.c
  * Privacy - hide channels in /WHOIS (User mode +p)
  * (C) Copyright 2000-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/usermodes/privdeaf.c
+++ b/src/modules/usermodes/privdeaf.c
@@ -1,7 +1,10 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/usermodes/privdeaf.c
  * usermode +D: makes it so you cannot receive private messages/notices
  * except from opers, U-lines and servers. -- Syzop
+ * GPLv2 or later
  */
+
 
 #include "unrealircd.h"
 

--- a/src/modules/usermodes/regonlymsg.c
+++ b/src/modules/usermodes/regonlymsg.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/usermodes/regonlymsg.c
  * Recieve private messages only from registered users (User mode +R)
  * (C) Copyright 2000-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/usermodes/secureonlymsg.c
+++ b/src/modules/usermodes/secureonlymsg.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/usermodes/secureonlymsg.c
  * Recieve private messages only from TLS users (User mode +Z)
  * (C) Copyright 2000-.. Bram Matthys (Syzop) and the UnrealIRCd team
  * Idea from "Stealth" <stealth@x-tab.org>

--- a/src/modules/usermodes/servicebot.c
+++ b/src/modules/usermodes/servicebot.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/usermodes/servicebot.c
  * Prevents you from being kicked (User mode +q)
  * (C) Copyright 2000-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/usermodes/showwhois.c
+++ b/src/modules/usermodes/showwhois.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/modules/usermodes/showwhois.c
  * Show when someone does a /WHOIS on you (User mode +W)
  * (C) Copyright 2000-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/webirc.c
+++ b/src/modules/webirc.c
@@ -1,4 +1,5 @@
 /*
+ * IRC - Internet Relay Chat, src/modules/webirc.c
  * WebIRC / CGI:IRC Support
  * (C) Copyright 2006-.. Bram Matthys (Syzop) and the UnrealIRCd team
  *

--- a/src/modules/webredir.c
+++ b/src/modules/webredir.c
@@ -1,4 +1,5 @@
 /*
+ * IRC - Internet Relay Chat, src/modules/webredir.c
  * webredir UnrealIRCd module
  * (C) Copyright 2019 i <info@servx.org> and the UnrealIRCd team
  *

--- a/src/modules/webserver.c
+++ b/src/modules/webserver.c
@@ -1,4 +1,5 @@
 /*
+ * IRC - Internet Relay Chat, src/modules/webserver.c
  * Webserver
  * (C)Copyright 2016 Bram Matthys and the UnrealIRCd team
  * License: GPLv2 or later

--- a/src/modules/websocket.c
+++ b/src/modules/websocket.c
@@ -1,4 +1,5 @@
 /*
+ * IRC - Internet Relay Chat, src/modules/websocket.c
  * websocket - WebSocket support (RFC6455)
  * (C)Copyright 2016 Bram Matthys and the UnrealIRCd team
  * License: GPLv2 or later

--- a/src/modules/websocket_common.c
+++ b/src/modules/websocket_common.c
@@ -1,4 +1,5 @@
 /*
+ * IRC - Internet Relay Chat, src/modules/websocket_common.c
  * websocket_common - Common WebSocket functions (RFC6455)
  * (C)Copyright 2016 Bram Matthys and the UnrealIRCd team
  * License: GPLv2 or later

--- a/src/modules/whowas.c
+++ b/src/modules/whowas.c
@@ -1,5 +1,5 @@
 /*
- *   IRC - Internet Relay Chat, src/modules/out.c
+ *   IRC - Internet Relay Chat, src/modules/whowas.c
  *   (C) 2004 The UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/modules/whowasdb.c
+++ b/src/modules/whowasdb.c
@@ -1,4 +1,5 @@
 /*
+ * IRC - Internet Relay Chat, src/modules/whowasdb.c
  * Stores WHOWAS history in a .db file
  * (C) Copyright 2023 Syzop
  * License: GPLv2 or later

--- a/src/modules/whox.c
+++ b/src/modules/whox.c
@@ -1,4 +1,6 @@
-/* cmd_whox.c / WHOX.
+/*
+ * IRC - Internet Relay Chat, src/modules/whox.c
+ * cmd_whox.c / WHOX.
  * based on code from charybdis and ircu.
  * was originally made for tircd and modified to work with u4.
  * - 2018 i <ircd@servx.org>

--- a/src/openssl_hostname_validation.c
+++ b/src/openssl_hostname_validation.c
@@ -1,4 +1,6 @@
-/* This file contains both code from cURL and hostname
+/*  
+ * IRC - Internet Relay Chat, src/openssl_hostname_validation.c
+ * This file contains both code from cURL and hostname
  * validation code from the ssl conservatory (in that order).
  *
  * The goal is that all this code won't be needed anymore once

--- a/src/operclass.c
+++ b/src/operclass.c
@@ -1,4 +1,6 @@
-/** Oper classes code.
+/** 
+ * IRC - Internet Relay Chat, src/operclass.c 
+ * Oper classes code.
  * (C) Copyright 2015-present tmcarthur and the UnrealIRCd team
  * License: GPLv2 or later
  */

--- a/src/random.c
+++ b/src/random.c
@@ -1,5 +1,5 @@
 /************************************************************************
- *   IRC - Internet Relay Chat, random.c
+ *   IRC - Internet Relay Chat, src/random.c
  *   (C) 2004-2019 Bram Matthys (Syzop) and the UnrealIRCd Team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/scache.c
+++ b/src/scache.c
@@ -1,4 +1,7 @@
-/* License: GPLv1 */
+/**  
+ * IRC - Internet Relay Chat, src/scache.c
+ * License: GPLv1
+ */
 
 /** @file
  * @brief String cache - only used for server names.

--- a/src/securitygroup.c
+++ b/src/securitygroup.c
@@ -1,4 +1,5 @@
-/*
+/* 
+ * IRC - Internet Relay Chat, src/securitygroup.c
  * Mask & security-group routines.
  * (C) Copyright 2015-.. Syzop and the UnrealIRCd team
  *

--- a/src/unrealircdctl.c
+++ b/src/unrealircdctl.c
@@ -1,5 +1,5 @@
 /************************************************************************
- *   UnrealIRCd - Unreal Internet Relay Chat Daemon - src/unrealircdctl
+ *   UnrealIRCd - Unreal Internet Relay Chat Daemon - src/unrealircdctl.c
  *   (c) 2022- Bram Matthys and The UnrealIRCd team
  *
  *   See file AUTHORS in IRC package for additional names of

--- a/src/url_curl.c
+++ b/src/url_curl.c
@@ -1,5 +1,5 @@
 /*
- *   Unreal Internet Relay Chat Daemon, src/url.c
+ *   Unreal Internet Relay Chat Daemon, src/url_curl.c
  *   (C) 2003 Dominick Meglio and the UnrealIRCd Team
  *   (C) 2004-2021 Bram Matthys <syzop@vulnscan.org>
  *   (C) 2012 William Pitcock <nenolod@dereferenced.org>

--- a/src/url_unreal.c
+++ b/src/url_unreal.c
@@ -1,5 +1,5 @@
 /*
- *   Unreal Internet Relay Chat Daemon, src/url.c
+ *   Unreal Internet Relay Chat Daemon, src/url_unreal.c
  *   (C) 2021 Bram Matthys and the UnrealIRCd team
  *
  *   This program is free software; you can redistribute it and/or modify

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -2,7 +2,9 @@
 
 /**************** UTF8 HELPER FUNCTIONS START HERE *****************/
 
-/* Operations on UTF-8 strings.
+/*  
+ * IRC - Internet Relay Chat, src/utf8.c
+ * Operations on UTF-8 strings.
  * This part is taken from "glib" with the following copyright:
  * Copyright (C) 1999 Tom Tromey
  * Copyright (C) 2000 Red Hat, Inc.


### PR DESCRIPTION
This is an IRCv3 extension which lets clients opt-out of receiving /names on join. This is useful for bots on large channels who do not need to know who is in the channel.

Specification: https://ircv3.net/specs/extensions/no-implicit-names

Edit: I am so sorry. I forgot to make a new branch when making the header edits.
In this case, this pull request also fixes incorrect headers and improves headers in files in the `src/modules/` directory recursively by adding consistency to the headers throughout by adding in:

```
 * IRC - Internet Relay Chat, src/modules/folder/file.c
 ```

Many of these headers displayed an incorrect file, mostly `out.c` and have been fixed.