### PR TITLE
Adjust config parser to log a warning when a block comment starts within another block comment.

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -1165,6 +1165,10 @@ ConfigFile *config_parse_with_offset(const char *filename, char *confdata, unsig
 						{
 							ptr++;
 							break;
+						} else if ((*ptr == '/') && (*(ptr+1) == '*'))
+						{
+							config_warn("%s:%i nested comments are not supported (comment started at line %d)\n",
+								filename, linenumber, commentstart);
 						}
 					}
 					if (!*ptr)
@@ -1286,7 +1290,7 @@ ConfigFile *config_parse_with_offset(const char *filename, char *confdata, unsig
 				{
 					if (preprocessor_level == 0)
 					{
-						config_error("%s:%i: @endif unexpected. There was no preciding unclosed @if.",
+						config_error("%s:%i: @endif unexpected. There was no preceding unclosed @if.",
 							filename, linenumber);
 						errors++;
 					}


### PR DESCRIPTION
This adjusts the following config block to be a warning, rather than silently ignoring (which can cause some minor confusion).

/* Link classes (missing a closing comment)
class hubs { ... }
/* Link blocks */
link ... { ... }