### PR TITLE
Move the set::modes-on-connect check to nick.c (after SASL) to consider account-based security groups

### DIFF
--- a/src/modules/nick.c
+++ b/src/modules/nick.c
@@ -837,6 +837,9 @@ void welcome_user(Client *client, TKL *viruschan_tkl)
 	if (client->umodes & UMODE_INVISIBLE)
 		irccounts.invisible++;
 
+	/* set::modes-on-connect */
+	client->umodes |= get_setting_for_user_number(client, SET_MODES_ON_CONNECT);
+	
 	build_umode_string(client, 0, SEND_UMODES|UMODE_SERVNOTICE, buf);
 
 	sendto_serv_butone_nickcmd(client->direction, NULL, client, (*buf == '\0' ? "+" : buf));

--- a/src/modules/user.c
+++ b/src/modules/user.c
@@ -88,9 +88,7 @@ CMD_FUNC(cmd_user)
 	realname = parv[4];
 	
 	make_user(client);
-
-	/* set::modes-on-connect */
-	client->umodes |= get_setting_for_user_number(client, SET_MODES_ON_CONNECT);
+	
 	client->user->server = me_hash;
 	strlcpy(client->info, realname, sizeof(client->info));
 	strlcpy(client->user->username, username, sizeof(client->user->username));


### PR DESCRIPTION
Hopefully this doesn't add other problems, everything seemed to go smoothly for me =]