### PR TITLE
Fix error when trying to listen using a websocket option.

### DIFF
--- a/doc/conf/rpc.modules.default.conf
+++ b/doc/conf/rpc.modules.default.conf
@@ -30,6 +30,7 @@
 /* These are required for RPC to work */
 loadmodule "webserver";
 loadmodule "websocket_common";
+laodmodule "websocket";
 
 /* And a RPC listen socket */
 @if !defined($NO_DEFAULT_RPC_SOCKET)

--- a/doc/conf/rpc.modules.default.conf
+++ b/doc/conf/rpc.modules.default.conf
@@ -30,7 +30,7 @@
 /* These are required for RPC to work */
 loadmodule "webserver";
 loadmodule "websocket_common";
-laodmodule "websocket";
+loadmodule "websocket";
 
 /* And a RPC listen socket */
 @if !defined($NO_DEFAULT_RPC_SOCKET)


### PR DESCRIPTION
It seems this is also needed in order to parse the listen block configuration, otherwise we get this message: [error] /home/ircd/unrealircd/conf/unrealircd.conf:245: Unknown listen::options option 'websocket'