### PR TITLE
Fix compile break for OPEROVERRIDE_VERIFY.

### DIFF
--- a/include/numeric.h
+++ b/include/numeric.h
@@ -536,7 +536,7 @@
 #define STR_ERR_OPERONLY		/* 520 */	":Cannot join channel %s (IRCops only)"
 #define STR_ERR_LISTSYNTAX		/* 521 */	":Bad list syntax, type /quote list ? or /raw list ?"
 #define STR_ERR_WHOLIMEXCEED		/* 523 */	":Error, /who limit of %d exceeded. Please narrow your search down and try again"
-#define STR_ERR_OPERSPVERIFY		/* 524 */	":Trying to join +s or +p channel as an oper. Please invite yourself first."
+#define STR_ERR_OPERSPVERIFY		/* 524 */	"%s :Trying to join +s or +p channel as an oper. Please invite yourself first."
 #define STR_ERR_CANTSENDTOUSER		/* 531 */	"%s :%s"
 #define STR_RPL_REAWAY			/* 597 */	"%s %s %s %lld :%s"
 #define STR_RPL_GONEAWAY		/* 598 */	"%s %s %s %lld :%s"

--- a/src/modules/join.c
+++ b/src/modules/join.c
@@ -127,8 +127,8 @@ int _can_join(Client *client, Channel *channel, const char *key, char **errmsg)
 
 #ifndef NO_OPEROVERRIDE
 #ifdef OPEROVERRIDE_VERIFY
-	if (ValidatePermissionsForPath("channel:override:privsecret",client,NULL,channel,NULL) && (channel->mode.mode & MODE_SECRET ||
-	    channel->mode.mode & MODE_PRIVATE))
+	if (ValidatePermissionsForPath("channel:override:privsecret",client,NULL,channel,NULL)
+		&& (SecretChannel(channel) || HiddenChannel(channel)))
 	{
 		*errmsg = STR_ERR_OPERSPVERIFY;
 		return (ERR_OPERSPVERIFY);


### PR DESCRIPTION
Fix compile break for OPEROVERRIDE_VERIFY.

Appears to have been introduced as part of the 6.x refactor of secret/private channel modes in 8066c13876c7ae2a76f42d657a7d6d092451aa5d

Reported by hnj in https://bugs.unrealircd.org/view.php?id=6418

-- 

Adjust message for ERR_OPERSPVERIFY to include channel name.

This is to correspond closer to other similar numerics around this area, as well as agreeing with the definition within modern.