### PR TITLE
comment optional, fictional example blocks

### DIFF
--- a/doc/conf/examples/example.conf
+++ b/doc/conf/examples/example.conf
@@ -131,12 +131,12 @@ allow {
  * Requires users on that IP to connect with a password. If the password
  * is correct then it permits 20 connections on that IP.
  */
-allow {
-	mask 192.0.2.1;
-	class clients;
-	password "somesecretpasswd";
-	maxperip 20;
-}
+// allow {
+// 	mask 192.0.2.1;
+// 	class clients;
+// 	password "somesecretpasswd";
+// 	maxperip 20;
+// }
 
 /* Oper blocks define your IRC Operators.
  * IRC Operators are people who have "extra rights" compared to others,
@@ -316,43 +316,43 @@ log {
 include "aliases/anope.conf";
 
 /* Ban nick names so they cannot be used by regular users */
-ban nick {
-	mask "*C*h*a*n*S*e*r*v*";
-	reason "Reserved for Services";
-}
+// ban nick {
+// 	mask "*C*h*a*n*S*e*r*v*";
+// 	reason "Reserved for Services";
+// }
 
 /* Ban ip.
  * Note that you normally use /KLINE, /GLINE and /ZLINE for this.
  */
-ban ip {
-	mask 195.86.232.81;
-	reason "Hate you";
-}
+// ban ip {
+// 	mask 195.86.232.81;
+// 	reason "Hate you";
+// }
 
 /* Ban server - if we see this server linked to someone then we delink */
-ban server {
-	mask eris.berkeley.edu;
-	reason "Get out of here.";
-}
+// ban server {
+// 	mask eris.berkeley.edu;
+// 	reason "Get out of here.";
+// }
 
 /* Ban user - just as an example, you normally use /KLINE or /GLINE for this */
-ban user {
-	mask *tirc@*.saturn.bbn.com;
-	reason "Idiot";
-}
+// ban user {
+// 	mask *tirc@*.saturn.bbn.com;
+// 	reason "Idiot";
+// }
 
 /* Ban realname allows you to ban clients based on their 'real name'
  * or 'gecos' field.
  */
-ban realname {
-	mask "Swat Team";
-	reason "mIRKFORCE";
-}
+// ban realname {
+// 	mask "Swat Team";
+// 	reason "mIRKFORCE";
+// }
 
-ban realname {
-	mask "sub7server";
-	reason "sub7";
-}
+// ban realname {
+// 	mask "sub7server";
+// 	reason "sub7";
+// }
 
 /* Ban and TKL exceptions. Allows you to exempt users / machines from
  * KLINE, GLINE, etc.
@@ -362,10 +362,10 @@ ban realname {
  */
 
 /* except ban with type 'all' protects you from GLINE, GZLINE, QLINE, SHUN */
-except ban {
-	mask *@192.0.2.1;
-	type all;
-}
+// except ban {
+// 	mask *@192.0.2.1;
+// 	type all;
+// }
 
 /* This allows IRCCloud connections in without maxperip restrictions
  * and also exempt them from connect-flood throttling.
@@ -376,17 +376,17 @@ except ban {
 }
 
 /* With deny dcc blocks you can ban filenames for DCC */
-deny dcc {
-	filename "*sub7*";
-	reason "Possible Sub7 Virus";
-}
+// deny dcc {
+// 	filename "*sub7*";
+// 	reason "Possible Sub7 Virus";
+// }
 
 /* deny channel allows you to ban a channel (mask) entirely */
-deny channel {
-	channel "*warez*";
-	reason "Warez is illegal";
-	class "clients";
-}
+// deny channel {
+// 	channel "*warez*";
+// 	reason "Warez is illegal";
+// 	class "clients";
+// }
 
 /* VHosts (Virtual Hosts) allow users to acquire a different host.
  * See https://www.unrealircd.org/docs/Vhost_block
@@ -396,12 +396,12 @@ deny channel {
  * NOTE: only people with an 'unrealircd.com' host may use it so
  *       be sure to change the vhost::mask before you test.
  */
-vhost {
-	vhost i.hate.microsefrs.com;
-	mask *@unrealircd.com;
-	login "test";
-	password "test";
-}
+// vhost {
+// 	vhost i.hate.microsefrs.com;
+// 	mask *@unrealircd.com;
+// 	login "test";
+// 	password "test";
+// }
 
 /* Blacklist blocks will query an external DNS Blacklist service
  * whenever a user connects, to see if the IP address is known


### PR DESCRIPTION
I commented config entries containing example or fictional data, such as IPs reserved for testing and documentation or random hostnames and IPs people likely have no reason to treat specially, or example strings like 'sub7', or example passwords.
I only commented blocks that are optional.