### PR TITLE
remove nonexistant email address

### DIFF
--- a/doc/conf/badwords.conf
+++ b/doc/conf/badwords.conf
@@ -5,7 +5,6 @@
  NOTE: Those words are not meant to insult you (the user)
        but is meant to be a list of words so that the +G channel/user mode 
        will work properly. You can easily modify this file at your will.
-       If you got words to add to this file, please mail badwords@tspre.org
 
  
 


### PR DESCRIPTION
does not seem to exist anymore:
```
13:09:55 [henk:~] % swaks --quit-after=RCPT --to=badwords@tspre.org
=== Trying mx1.pub.mailpod11-cph3.one.com:25...
=== Connected to mx1.pub.mailpod11-cph3.one.com.
<-  220 mx1.pub.mailpod11-cph3.one.com ESMTP
 -> EHLO frustcomp.hnjs.home.arpa
<-  250-mx1.pub.mailpod11-cph3.one.com
<-  250-PIPELINING
<-  250-SIZE 104857600
<-  250-STARTTLS
<-  250-ENHANCEDSTATUSCODES
<-  250 8BITMIME
 -> MAIL FROM:<henk@frustcomp.hnjs.home.arpa>
<-  250 2.1.0 Ok
 -> RCPT TO:<badwords@tspre.org>
<** 550 5.1.1 Unknown recipient
 -> QUIT
<-  221 2.0.0 Bye
=== Connection closed with remote host.
```