### PR TITLE
MODE: Reply with ERR_NOSUCHCHANNEL when the target is a channel

### DIFF
--- a/src/modules/mode.c
+++ b/src/modules/mode.c
@@ -107,7 +107,7 @@ CMD_FUNC(cmd_mode)
 			channel = find_channel(parv[1]);
 			if (!channel)
 			{
-				CALL_CMD_FUNC(cmd_umode);
+				sendnumeric(client, ERR_NOSUCHCHANNEL, parv[1]);
 				return;
 			}
 		} else


### PR DESCRIPTION
While it is common for IRC servers to use ERR_NOSUCHNICK instead of ERR_NOSUCHCHANNEL when a target can be either a channel or a nick, it seems every other IRCd but ngIRCd uses ERR_NOSUCHCHANNEL in this particular case. (similar PR sent to ngIRCd: https://github.com/ngircd/ngircd/pull/319)