### PR TITLE
Verify upstream issuer's name can be used properly in places on IRC

### DIFF
--- a/src/modules/issued-by-tag.c
+++ b/src/modules/issued-by-tag.c
@@ -124,7 +124,14 @@ void _mtag_add_issued_by(MessageTag **mtags, Client *client, MessageTag *recv_mt
 		// TODO: test with all of: local rpc through unix socket, local rpc web, RRPC
 		if (client->rpc->issuer)
 		{
-			snprintf(buf, sizeof(buf), "RPC:%s@%s:%s", client->rpc->rpc_user, client->uplink->name, client->rpc->issuer);
+			// For several places in the source, like TOPIC
+			// we cannot explicitly trust the uplink issuer's
+			// name because it might contain spaces and that's
+			// not good. It must conform to IRC nick standards.
+			if (!do_nick_name(client->rpc->issuer)) 
+				return;
+			else
+				snprintf(buf, sizeof(buf), "RPC:%s@%s:%s", client->rpc->rpc_user, client->uplink->name, client->rpc->issuer);
 		} else {
 			snprintf(buf, sizeof(buf), "RPC:%s@%s", client->rpc->rpc_user, client->uplink->name);
 		}


### PR DESCRIPTION
I made an account on my webpanel with a space in the username just to see what would happen, changed the topic of a channel and things got a bit messy due to explicitly trusting that it can be used on IRC.

I'm going to fix that in the webpanel also, but it doesn't stop other devs from potentially breaking things with their own software. So I think we should just do this to be safe.