### PR TITLE
Fix redefinition of struct RPCClient within struct.h.

### DIFF
--- a/include/struct.h
+++ b/include/struct.h
@@ -1557,7 +1557,6 @@ struct Server {
 
 /** @} */
 
-typedef struct RPCClient RPCClient;
 /** RPC Client information */
 struct RPCClient {
 	char *rpc_user; /**< Name of the rpc-user block after authentication, NULL during pre-auth */


### PR DESCRIPTION
Fix redefinition of struct RPCClient within struct.h, which occurs you have an old compiler.

Reported in https://bugs.unrealircd.org/view.php?id=6469 by hughmungus