### PR TITLE
wocket.c - Update buffer size to account for messagetags

### DIFF
--- a/src/modules/websocket.c
+++ b/src/modules/websocket.c
@@ -296,7 +296,12 @@ int websocket_handle_body_websocket(Client *client, WebRequest *web, const char 
  */
 int websocket_packet_out(Client *from, Client *to, Client *intended_to, char **msg, int *length)
 {
-	static char utf8buf[510];
+	/* 8192 = MessageTag max length
+ 	 * 512 = IRC line length
+   	 * 1 = the space between them
+	 * 1 = NULL terminator?
+ 	*/
+	static char utf8buf[8192+512+1+1];
 
 	if (MyConnect(to) && !IsRPC(to) && websocket_md && WSU(to) && WSU(to)->handshake_completed)
 	{


### PR DESCRIPTION
Allow full mtag messages to be sent over wockets
Special thanks to alice for pointing out the buffer length issue and specifying the message-tag length