### PR TITLE
Tell clients about `CHANMODE`, `PREFIX` and `STATUSMSG` changes at runtime

### DIFF
--- a/src/api-channelmode.c
+++ b/src/api-channelmode.c
@@ -145,6 +145,11 @@ void extcmodes_check_for_changed_channel_modes(void)
 		           log_data_string("new_channel_modes", chanmodes));
 		/* Broadcast change to all (locally connected) servers */
 		sendto_server(NULL, 0, 0, NULL, "PROTOCTL CHANMODES=%s", chanmodes);
+
+		/* Tell locally connected user about the change*/
+		Client *cptr;
+		list_for_each_entry(cptr, &lclient_list, lclient_node)
+			sendto_one(cptr, NULL, ":%s 005 %s CHANMODES=%s", me.name, cptr->name, chanmodes);
 	}
 
 	strlcpy(previous_chanmodes, chanmodes, sizeof(previous_chanmodes));
@@ -221,6 +226,11 @@ void extcmodes_check_for_changed_prefixes(void)
 		           log_data_string("new_prefix", prefix));
 		/* Broadcast change to all (locally connected) servers */
 		sendto_server(NULL, 0, 0, NULL, "PROTOCTL PREFIX=%s", prefix);
+
+		/* Tell locally connected user about the change*/
+		Client *cptr;
+		list_for_each_entry(cptr, &lclient_list, lclient_node)
+			sendto_one(cptr, NULL, ":%s 005 %s PREFIX=%s STATUSMSG=%s", me.name, cptr->name, prefix, statusmsg);
 	}
 
 	strlcpy(previous_prefix, prefix, sizeof(previous_prefix));


### PR DESCRIPTION
This re-sends these ISUPPORT tokens to let users know about important changes that may affect their display, most notably `PREFIX` can be problematic; for example if you have a server running and wish to load a module like ojoin or something else that relies on the client knowing the correlation between the mode and the prefix char, and without it the client just doesn't display the nicklist properly from then on until the client reconnects, which as we know can be a while until that happens.

The expected client reaction to duplicate ISUPPORT tokens according to the spec is to overwrite the current values. I have tested this in mIRC only and it works as expected.