### PR TITLE
Add `HOOKTYPE_CAN_USE_NICK`, useful for blocking on an internal level like "IRC" nick

### DIFF
--- a/include/modules.h
+++ b/include/modules.h
@@ -1542,7 +1542,7 @@ int hooktype_pre_chanmsg(Client *client, Channel *channel, MessageTag **mtags, c
  * @retval HOOK_DENY		Deny the message. The 'errmsg' will be sent to the user.
  * @retval HOOK_CONTINUE	Allow the message, unless other modules block it.
  */
-int hooktype_can_send_to_user(Client *client, Client *target, const char **text, const char **errmsg, SendType sendtype);
+int hooktype_can_send_to_user(Client *client, Client *target, const char **text, const char **errmsg, SendType sendtype, ClientContext *clictx);
 
 /** Called when a user wants to send a message to a channel (function prototype for HOOKTYPE_CAN_SEND_TO_CHANNEL).
  * @param client		The sender
@@ -1554,7 +1554,7 @@ int hooktype_can_send_to_user(Client *client, Client *target, const char **text,
  * @retval HOOK_DENY		Deny the message. The 'errmsg' will be sent to the user.
  * @retval HOOK_CONTINUE	Allow the message, unless other modules block it.
  */
-int hooktype_can_send_to_channel(Client *client, Channel *channel, Membership *member, const char **text, const char **errmsg, SendType sendtype);
+int hooktype_can_send_to_channel(Client *client, Channel *channel, Membership *member, const char **text, const char **errmsg, SendType sendtype, ClientContext *clictx);
 
 /** Called when a message is sent from one user to another user (function prototype for HOOKTYPE_USERMSG).
  * @param client		The sender

--- a/include/modules.h
+++ b/include/modules.h
@@ -998,12 +998,12 @@ extern void CommandDelX(Command *command, RealCommand *cmd);
 extern int CommandExists(const char *name);
 extern CommandOverride *CommandOverrideAdd(Module *module, const char *name, int priority, OverrideCmdFunc func);
 extern void CommandOverrideDel(CommandOverride *ovr);
-extern void CallCommandOverride(CommandOverride *ovr, ClientContext *clictx, Client *client, MessageTag *mtags, int parc, const char *parv[]);
+extern void CallCommandOverride(CommandOverride *ovr, Client *client, MessageTag *mtags, int parc, const char *parv[]);
 /** Call next command override function - easy way to do it.
  * This way you don't have to call CallCommandOverride() with the right arguments.
  * Which is nice because command (override) arguments may change in future UnrealIRCd versions.
  */
-#define CALL_NEXT_COMMAND_OVERRIDE()	CallCommandOverride(ovr, clictx, client, recv_mtags, parc, parv)
+#define CALL_NEXT_COMMAND_OVERRIDE()	CallCommandOverride(ovr, client, recv_mtags, parc, parv)
 
 extern void moddata_free_client(Client *acptr);
 extern void moddata_free_local_client(Client *acptr);
@@ -1310,10 +1310,8 @@ extern APICallback *APICallbackAdd(Module *module, APICallback *mreq);
 #define HOOKTYPE_SASL_AUTHENTICATE	124
 /** See hooktype_sasl_mechs */
 #define HOOKTYPE_SASL_MECHS		125
-/* See hooktype_allow_client */
-#define HOOKTYPE_ALLOW_CLIENT	126
-/** See hooktype_analyze_text */
-#define HOOKTYPE_ANALYZE_TEXT	127
+/** See hooktype_can_use_nick */
+#define HOOKTYPE_CAN_USE_NICK	126
 
 /* Adding a new hook here?
  * 1) Add the #define HOOKTYPE_.... with a new number
@@ -1526,7 +1524,7 @@ int hooktype_local_kick(Client *client, Client *victim, Channel *channel, Messag
 int hooktype_remote_kick(Client *client, Client *victim, Channel *channel, MessageTag *mtags, const char *comment);
 
 /** Called right before a message is sent to the channel (function prototype for HOOKTYPE_PRE_CHANMSG).
- * This function is only used by delayjoin. It cannot block a message. See hooktype_can_send_to_channel() instead!
+ * This function is only used by delayjoin. It cannot block a message. See hooktype_can_send_to_user() instead!
  * @param client		The client
  * @param channel		The channel
  * @param mtags         	Message tags associated with the event (pointer-to-pointer)
@@ -1544,7 +1542,7 @@ int hooktype_pre_chanmsg(Client *client, Channel *channel, MessageTag **mtags, c
  * @retval HOOK_DENY		Deny the message. The 'errmsg' will be sent to the user.
  * @retval HOOK_CONTINUE	Allow the message, unless other modules block it.
  */
-int hooktype_can_send_to_user(Client *client, Client *target, const char **text, const char **errmsg, SendType sendtype, ClientContext *clictx);
+int hooktype_can_send_to_user(Client *client, Client *target, const char **text, const char **errmsg, SendType sendtype);
 
 /** Called when a user wants to send a message to a channel (function prototype for HOOKTYPE_CAN_SEND_TO_CHANNEL).
  * @param client		The sender
@@ -1556,7 +1554,7 @@ int hooktype_can_send_to_user(Client *client, Client *target, const char **text,
  * @retval HOOK_DENY		Deny the message. The 'errmsg' will be sent to the user.
  * @retval HOOK_CONTINUE	Allow the message, unless other modules block it.
  */
-int hooktype_can_send_to_channel(Client *client, Channel *channel, Membership *member, const char **text, const char **errmsg, SendType sendtype, ClientContext *clictx);
+int hooktype_can_send_to_channel(Client *client, Channel *channel, Membership *member, const char **text, const char **errmsg, SendType sendtype);
 
 /** Called when a message is sent from one user to another user (function prototype for HOOKTYPE_USERMSG).
  * @param client		The sender
@@ -2296,7 +2294,7 @@ int hooktype_post_local_nickchange(Client *client, MessageTag *mtags, const char
  */
 int hooktype_post_remote_nickchange(Client *client, MessageTag *mtags, const char *oldnick);
 
-/** Called when user name or user host has changed (function prototype for HOOKTYPE_USERHOST_CHANGE).
+/** Called when user name or user host has changed.
  * @param client		The client whose user@host has changed
  * @param olduser		Old username of the client
  * @param oldhost		Old hostname of the client
@@ -2304,14 +2302,14 @@ int hooktype_post_remote_nickchange(Client *client, MessageTag *mtags, const cha
  */
 int hooktype_userhost_change(Client *client, const char *olduser, const char *oldhost);
 
-/** Called when user realname has changed.  (function prototype for HOOKTYPE_REALNAME_CHANGE).
+/** Called when user realname has changed.
  * @param client		The client whose realname has changed
  * @param oldinfo		Old realname of the client
  * @return The return value is ignored (use return 0)
  */
 int hooktype_realname_change(Client *client, const char *oldinfo);
 
-/** Called when changing IP (eg due to PROXY/WEBIRC/etc) (function prototype for HOOKTYPE_IP_CHANGE).
+/** Called when changing IP (eg due to PROXY/WEBIRC/etc).
  * @param client		The client whose IP has changed
  * @param oldip			Old IP of the client
  * @returns If you reject the user then use dead_link() and return HOOK_DENY
@@ -2320,7 +2318,7 @@ int hooktype_realname_change(Client *client, const char *oldinfo);
  */
 int hooktype_ip_change(Client *client, const char *oldip);
 
-/** Called when json_expand_client() is called (function prototype for HOOKTYPE_JSON_EXPAND_CLIENT).
+/** Called when json_expand_client() is called.
  * Used for expanding information about 'client' in logging routines.
  * @param client		The client that should be expanded
  * @param detail		The amount of detail to provide (always 0 at the moment)
@@ -2329,7 +2327,7 @@ int hooktype_ip_change(Client *client, const char *oldip);
  */
 int hooktype_json_expand_client(Client *client, int detail, json_t *j);
 
-/** Called when json_expand_client_user() is called (function prototype for HOOKTYPE_JSON_EXPAND_CLIENT_USER).
+/** Called when json_expand_client_user() is called.
  * Used for expanding information about 'client' in logging routines
  * when the client is a USER.
  * @param client		The client that should be expanded
@@ -2340,7 +2338,7 @@ int hooktype_json_expand_client(Client *client, int detail, json_t *j);
  */
 int hooktype_json_expand_client_user(Client *client, int detail, json_t *j, json_t *child);
 
-/** Called when json_expand_client_server() is called (function prototype for HOOKTYPE_JSON_EXPAND_CLIENT_SERVER).
+/** Called when json_expand_client_server() is called.
  * Used for expanding information about 'client' in logging routines
  * when the client is a SERVER.
  * @param client		The client that should be expanded
@@ -2351,7 +2349,7 @@ int hooktype_json_expand_client_user(Client *client, int detail, json_t *j, json
  */
 int hooktype_json_expand_client_server(Client *client, int detail, json_t *j, json_t *child);
 
-/** Called when json_expand_channel() is called (function prototype for HOOKTYPE_JSON_EXPAND_CHANNEL).
+/** Called when json_expand_channel() is called.
  * Used for expanding information about 'channel' in logging routines.
  * @param channel		The channel that should be expanded
  * @param detail		The amount of detail to provide (always 0 at the moment)
@@ -2370,28 +2368,29 @@ int hooktype_json_expand_channel(Channel *channel, int detail, json_t *j);
  */
 int hooktype_pre_local_handshake_timeout(Client *client, const char **comment);
 
-/** Called when a REHASH completed (either succesfully or with a failure) (function prototype for HOOKTYPE_REHASH_LOG).
- * This gives the full rehash log. Used by the JSON-RPC interface.
+/** Called when a REHASH completed (either succesfully or with a failure).
+ * This gives the full rehash log. Used by the JSON-RPC interface. (function prototype for HOOKTYPE_REHASH_LOG)
  * @param failure		Set to 1 if the rehash failed, otherwise 0.
  * @param t			The JSON object containing the rehash log and other information.
  * @return The return value is ignored (use return 0)
  */
 int hooktype_rehash_log(int failure, json_t *rehash_log);
 
-/** Called when DNS has been done for a client (or has not been done because it was skipped)
- * (function prototype for HOOKTYPE_DNS_FINISHED).
+/** Called when DNS has been done for a client (or has not been done because it was skipped).
+ * (function prototype for HOOKTYPE_DNS_FINISHED)
  * @param client		The client
  * @return The return value is ignored (use return 0)
  */
 int hooktype_dns_finished(Client *client);
 
-/** Called after an listener block is processed (function prototype for HOOKTYPE_CONFIG_LISTENER).
+/** Called after an listener block is processed
+ * (function prototype for HOOKTYPE_CONFIG_LISTENER)
  * @param listener		The listener
  * @return The return value is ignored (use return 0)
  */
 int hooktype_config_listener(ConfigItem_listen *listener);
 
-/** Called after an entry is added to a WATCH (or MONITOR) list (function prototype for HOOKTYPE_WATCH_ADD).
+/** Called after an entry is added to a WATCH (or MONITOR) list.
  * @param nick	Name of the new entry (watched user's nick)
  * @param client	Owner of the watch list
  * @param flags	Flags for the entry (WATCH_FLAG_TYPE_*)
@@ -2399,7 +2398,7 @@ int hooktype_config_listener(ConfigItem_listen *listener);
  */
 int hooktype_watch_add(char *nick, Client *client, int flags);
 
-/** Called after an entry is removed from a WATCH (or MONITOR) list (function prototype for HOOKTYPE_WATCH_DEL).
+/** Called after an entry is removed from a WATCH (or MONITOR) list.
  * @param nick	Name of the entry (watched user's nick) to be deleted
  * @param client	Owner of the watch list
  * @param flags	Flags for the entry (WATCH_FLAG_TYPE_*) to be deleted
@@ -2407,8 +2406,7 @@ int hooktype_watch_add(char *nick, Client *client, int flags);
  */
 int hooktype_watch_del(char *nick, Client *client, int flags);
 
-/** Called when an user is notified about a MONITORed nick coming off- or online
- * (function prototype for HOOKTYPE_MONITOR_NOTIFICATION).
+/** Called when an user is notified about a MONITORed nick coming off- or online.
  * @param watcher	The user being notified
  * @param client	The user (dis)appearing
  * @param online	1 if it's coming online, 0 otherwise
@@ -2416,8 +2414,7 @@ int hooktype_watch_del(char *nick, Client *client, int flags);
  */
 int hooktype_monitor_notification(Client *watcher, Client *client, int online);
 
-/** Called when an AUTHENTICATE command is sent by the client, for SASL authentication
- * (function prototype for HOOKTYPE_SASL_AUTHENTICATE).
+/** Called when an AUTHENTICATE command is sent by the client, for SASL authentication.
  * This can be used by authentication modules.
  * @param client		The client (user)
  * @param first			Set to 1 if this is the first AUTHENTICATE, set to 0 if it is a continuation.
@@ -2432,28 +2429,14 @@ int hooktype_sasl_authenticate(Client *client, int first, const char *param);
  */
 const char *hooktype_sasl_mechs(Client *client);
 
-/** Called from AllowClient() to see if the client should be allowed in based
- * on allow block restrictions (function prototype for HOOKTYPE_ALLOW_CLIENT).
- * NOTE for 3rd party modules: usually you will want to use
- * HOOKTYPE_PRE_LOCAL_CONNECT instead (or sometimes HOOKTYPE_IS_HANDSHAKE_FINISHED),
- * as this HOOKTYPE_ALLOW_CLIENT is really meant for allow-block-specific stuff.
- * @param client	The client
- * @param aconf		The allow block being evaluated
- * @return A string that will be used to exit_client() to reject the user,
- * or NULL to allow the user in.
- */
-const char *hooktype_allow_client(Client *client, ConfigItem_allow *aconf);
-
-/** Called from PRIVMSG/NOTICE to analyze properties of text-to-be-sent
- * (function prototype for HOOKTYPE_ANALYZE_TEXT).
- * @param client	The client
- * @param text		The text that the user wants to send
- * @param e		The result of the analysis
- * @notes Since multiple modules can be called, 'e' may already contain data,
- *        so don't blindly assume it is all zeroed (and don't zero everything either).
- * @return The return value is ignored (use return 0)
- */
-int hooktype_analyze_text(Client *client, const char *text, TextAnalysis *e);
+/** Called when a user wants to change their nick
+ * @param client		The client
+ * @param newnick		The new nick the user wants to change to
+ * @param reject_reason	Pointer to a string that can be set to a reason why the nick change is rejected.
+ * @retval HOOK_DENY		Deny the nick change, set *reject_reason to a reason why it is denied.
+ * @retval HOOK_CONTINUE 	Allow the nick change, unless blocked by something else.
+*/
+int hooktype_can_use_nick(Client *client, const char *newnick, const char **reject_reason);
 /** @} */
 
 #ifdef GCC_TYPECHECKING
@@ -2582,8 +2565,7 @@ _UNREAL_ERROR(_hook_error_incompatible, "Incompatible hook function. Check argum
         ((hooktype == HOOKTYPE_MONITOR_NOTIFICATION) && !ValidateHook(hooktype_monitor_notification, func)) || \
         ((hooktype == HOOKTYPE_SASL_AUTHENTICATE) && !ValidateHook(hooktype_sasl_authenticate, func)) || \
         ((hooktype == HOOKTYPE_SASL_MECHS) && !ValidateHook(hooktype_sasl_mechs, func)) || \
-        ((hooktype == HOOKTYPE_ALLOW_CLIENT) && !ValidateHook(hooktype_allow_client, func)) || \
-        ((hooktype == HOOKTYPE_ANALYZE_TEXT) && !ValidateHook(hooktype_analyze_text, func))) \
+		((hooktype == HOOKTYPE_CAN_USE_NICK) && !ValidateHook(hooktype_can_use_nick, func))) \
         _hook_error_incompatible();
 #endif /* GCC_TYPECHECKING */
 
@@ -2749,10 +2731,6 @@ enum EfunctionType {
 	EFUNC_EXIT_CLIENT_EX,
 	EFUNC_BANNED_CLIENT,
 	EFUNC_UNREAL_EXPAND_STRING,
-	EFUNC_UTF8_CONVERT_CONFUSABLES,
-	EFUNC_UTF8_ANALYZE_TEXT,
-	EFUNC_UTF8_GET_BLOCK_NAME,
-	EFUNC_UTF8_GET_BLOCK_NUMBER,
 };
 
 /* Module flags */
@@ -2779,8 +2757,6 @@ enum EfunctionType {
 #define CONFIG_LISTEN 10
 #define CONFIG_LISTEN_OPTIONS 11
 #define CONFIG_SET_HISTORY_CHANNEL 12
-#define CONFIG_ALLOW_BLOCK 13
-#define CONFIG_CLASS 14
 
 #define MOD_HEADER Mod_Header
 #define MOD_TEST() DLLFUNC int Mod_Test(ModuleInfo *modinfo)

--- a/src/modules/nick.c
+++ b/src/modules/nick.c
@@ -45,7 +45,23 @@ ModuleHeader MOD_HEADER
  */
 #define ASSUME_NICK_IN_FLIGHT
 
+#define IPUSERS_HASH_TABLE_SIZE 8192
+
+/* Structs */
+typedef struct IpUsersBucket IpUsersBucket;
+struct IpUsersBucket
+{
+	IpUsersBucket *prev, *next;
+	char rawip[16];
+	int local_clients;
+	int global_clients;
+};
+
+/* Variables */
 static char spamfilter_user[NICKLEN + USERLEN + HOSTLEN + REALLEN + 64];
+IpUsersBucket **IpUsersHash_ipv4 = NULL;
+IpUsersBucket **IpUsersHash_ipv6 = NULL;
+char *siphashkey_ipusers = NULL;
 
 /* Forward declarations */
 CMD_FUNC(cmd_nick);
@@ -55,6 +71,14 @@ CMD_FUNC(cmd_uid);
 int _register_user(Client *client);
 void nick_collision(Client *cptr, const char *newnick, const char *newid, Client *new, Client *existing, int type);
 int AllowClient(Client *client);
+int exceeds_maxperip(Client *client, ConfigItem_allow *aconf);
+void siphashkey_ipusers_free(ModData *m);
+void ipusershash_free_4(ModData *m);
+void ipusershash_free_6(ModData *m);
+IpUsersBucket *add_ipusers_bucket(Client *client);
+void decrease_ipusers_bucket(Client *client);
+int decrease_ipusers_bucket_wrapper(Client *client);
+int stats_maxperip(Client *client, const char *para);
 char *_unreal_expand_string(const char *str, char *buf, size_t buflen, NameValuePrioList *nvp, int buildvarstring_options, Client *client);
 
 MOD_TEST()
@@ -69,9 +93,24 @@ MOD_INIT()
 {
 	MARK_AS_OFFICIAL_MODULE(modinfo);
 
+	LoadPersistentPointer(modinfo, siphashkey_ipusers, siphashkey_ipusers_free);
+	if (!siphashkey_ipusers)
+	{
+		siphashkey_ipusers = safe_alloc(SIPHASH_KEY_LENGTH);
+		siphash_generate_key(siphashkey_ipusers);
+	}
+	LoadPersistentPointer(modinfo, IpUsersHash_ipv4, ipusershash_free_4);
+	if (!IpUsersHash_ipv4)
+		IpUsersHash_ipv4 = safe_alloc(sizeof(IpUsersBucket *) * IPUSERS_HASH_TABLE_SIZE);
+	LoadPersistentPointer(modinfo, IpUsersHash_ipv6, ipusershash_free_6);
+	if (!IpUsersHash_ipv6)
+		IpUsersHash_ipv6 = safe_alloc(sizeof(IpUsersBucket *) * IPUSERS_HASH_TABLE_SIZE);
+
 	CommandAdd(modinfo->handle, "NICK", cmd_nick, MAXPARA, CMD_USER|CMD_SERVER|CMD_UNREGISTERED);
 	CommandAdd(modinfo->handle, "UID", cmd_uid, MAXPARA, CMD_SERVER);
 
+	HookAdd(modinfo->handle, HOOKTYPE_FREE_USER, 0, decrease_ipusers_bucket_wrapper);
+	HookAdd(modinfo->handle, HOOKTYPE_STATS, 0, stats_maxperip);
 	return MOD_SUCCESS;
 }
 
@@ -82,7 +121,177 @@ MOD_LOAD()
 
 MOD_UNLOAD()
 {
+	SavePersistentPointer(modinfo, siphashkey_ipusers);
+	SavePersistentPointer(modinfo, IpUsersHash_ipv4);
+	SavePersistentPointer(modinfo, IpUsersHash_ipv6);
 	return MOD_SUCCESS;
+}
+
+void siphashkey_ipusers_free(ModData *m)
+{
+	safe_free(siphashkey_ipusers);
+	m->ptr = NULL;
+}
+
+void ipusershash_free_4(ModData *m)
+{
+	// FIXME: need to free every bucket in a for loop
+	// and then end with this:
+	safe_free(IpUsersHash_ipv4);
+	m->ptr = NULL;
+}
+
+void ipusershash_free_6(ModData *m)
+{
+	// FIXME: need to free every bucket in a for loop
+	// and then end with this:
+	safe_free(IpUsersHash_ipv6);
+	m->ptr = NULL;
+}
+
+uint64_t hash_ipusers(Client *client)
+{
+	if (IsIPV6(client))
+		return siphash_raw(client->rawip, 16, siphashkey_ipusers) % IPUSERS_HASH_TABLE_SIZE;
+	else
+		return siphash_raw(client->rawip, 4, siphashkey_ipusers) % IPUSERS_HASH_TABLE_SIZE;
+}
+
+IpUsersBucket *find_ipusers_bucket(Client *client)
+{
+	int hash = 0;
+	IpUsersBucket *p;
+
+	hash = hash_ipusers(client);
+
+	if (IsIPV6(client))
+	{
+		for (p = IpUsersHash_ipv6[hash]; p; p = p->next)
+			if (memcmp(p->rawip, client->rawip, 16) == 0)
+				return p;
+	} else {
+		for (p = IpUsersHash_ipv4[hash]; p; p = p->next)
+			if (memcmp(p->rawip, client->rawip, 4) == 0)
+				return p;
+	}
+
+	return NULL;
+}
+
+/* (wrapper needed because hook has return type 'int' and function is 'void' */
+int decrease_ipusers_bucket_wrapper(Client *client)
+{
+	decrease_ipusers_bucket(client);
+	return 0;
+}
+
+IpUsersBucket *add_ipusers_bucket(Client *client)
+{
+	int hash;
+	IpUsersBucket *n;
+
+	hash = hash_ipusers(client);
+
+	n = safe_alloc(sizeof(IpUsersBucket));
+	if (IsIPV6(client))
+	{
+		memcpy(n->rawip, client->rawip, 16);
+		AddListItem(n, IpUsersHash_ipv6[hash]);
+	} else {
+		memcpy(n->rawip, client->rawip, 4);
+		AddListItem(n, IpUsersHash_ipv4[hash]);
+	}
+	return n;
+}
+
+void decrease_ipusers_bucket(Client *client)
+{
+	int hash = 0;
+	IpUsersBucket *p;
+
+	if (!(client->flags & CLIENT_FLAG_IPUSERS_BUMPED))
+		return; /* nothing to do */
+
+	client->flags &= ~CLIENT_FLAG_IPUSERS_BUMPED;
+
+	hash = hash_ipusers(client);
+
+	if (IsIPV6(client))
+	{
+		for (p = IpUsersHash_ipv6[hash]; p; p = p->next)
+			if (memcmp(p->rawip, client->rawip, 16) == 0)
+				break;
+	} else {
+		for (p = IpUsersHash_ipv4[hash]; p; p = p->next)
+			if (memcmp(p->rawip, client->rawip, 4) == 0)
+				break;
+	}
+
+	if (!p)
+	{
+		unreal_log(ULOG_INFO, "user", "BUG_DECREASE_IPUSERS_BUCKET", client,
+		           "[BUG] decrease_ipusers_bucket() called but bucket is gone for client $client.details");
+		return;
+	}
+
+	p->global_clients--;
+	if (MyConnect(client))
+		p->local_clients--;
+
+	if ((p->global_clients == 0) && (p->local_clients == 0))
+	{
+		if (IsIPV6(client))
+			DelListItem(p, IpUsersHash_ipv6[hash]);
+		else
+			DelListItem(p, IpUsersHash_ipv4[hash]);
+		safe_free(p);
+	}
+}
+
+int stats_maxperip(Client *client, const char *para)
+{
+	int i;
+	IpUsersBucket *e;
+	char ipbuf[256];
+	const char *ip;
+
+	/* '/STATS 8' or '/STATS maxperip' is for us... */
+	if (strcmp(para, "8") && strcasecmp(para, "maxperip"))
+		return 0;
+
+	if (!ValidatePermissionsForPath("server:info:stats",client,NULL,NULL,NULL))
+	{
+		sendnumeric(client, ERR_NOPRIVILEGES);
+		return 0;
+	}
+
+	sendtxtnumeric(client, "MaxPerIp IPv4 hash table:");
+	for (i=0; i < IPUSERS_HASH_TABLE_SIZE; i++)
+	{
+		for (e = IpUsersHash_ipv4[i]; e; e = e->next)
+		{
+			ip = inetntop(AF_INET, e->rawip, ipbuf, sizeof(ipbuf));
+			if (!ip)
+				ip = "<invalid>";
+			sendtxtnumeric(client, "IPv4 #%d %s: %d local / %d global",
+				       i, ip, e->local_clients, e->global_clients);
+		}
+	}
+
+	sendtxtnumeric(client, "MaxPerIp IPv6 hash table:");
+	for (i=0; i < IPUSERS_HASH_TABLE_SIZE; i++)
+	{
+		for (e = IpUsersHash_ipv6[i]; e; e = e->next)
+		{
+			ip = inetntop(AF_INET6, e->rawip, ipbuf, sizeof(ipbuf));
+			if (!ip)
+				ip = "<invalid>";
+			sendtxtnumeric(client, "IPv6 #%d %s: %d local / %d global",
+				       i, ip, e->local_clients, e->global_clients);
+		}
+	}
+
+	return 0;
 }
 
 /** Hmm.. don't we already have such a function? */
@@ -272,7 +481,7 @@ CMD_FUNC(cmd_nick_local)
 	{
 		/* Local client changing nick: check spamfilter */
 		spamfilter_build_user_string(spamfilter_user, nick, client);
-		if (match_spamfilter(client, spamfilter_user, SPAMF_USER, "NICK", NULL, 0, clictx, NULL))
+		if (match_spamfilter(client, spamfilter_user, SPAMF_USER, "NICK", NULL, 0, NULL))
 			return;
 	}
 
@@ -302,6 +511,22 @@ CMD_FUNC(cmd_nick_local)
 	if (!ValidatePermissionsForPath("immune:nick-flood",client,NULL,NULL,NULL))
 		add_fake_lag(client, 3000);
 
+	char *change_nick_error_from_hook = NULL;
+	for (h = Hooks[HOOKTYPE_CAN_USE_NICK]; h; h = h->next)
+	{
+		int ret = (*(h->func.intfunc))(client, nick, &change_nick_error_from_hook);
+		if (ret == HOOK_DENY)
+		{
+			if (change_nick_error_from_hook)
+			{
+				sendnumeric(client, ERR_ERRONEUSNICKNAME, nick, change_nick_error_from_hook);
+				safe_free(change_nick_error_from_hook);
+			} else {
+				sendnumeric(client, ERR_ERRONEUSNICKNAME, nick, "Denied by hook");
+			}
+			return;
+		}
+	}
 	if ((acptr = find_client(nick, NULL)))
 	{
 		/* Shouldn't be possible since dot is disallowed: */
@@ -496,6 +721,7 @@ CMD_FUNC(cmd_uid)
 	int differ = 1;
 	const char *hostname, *username, *sstamp, *umodes, *virthost, *ip_raw, *realname;
 	const char *ip = NULL;
+	Hook *h;
 
 	if (parc < 13)
 	{
@@ -612,6 +838,7 @@ CMD_FUNC(cmd_uid)
 		/* Let it through */
 	}
 
+
 	/* Now check if 'nick' already exists - collision with a user (or still in handshake, unknown) */
 	if ((acptr = find_client(nick, NULL)) != NULL)
 	{
@@ -715,6 +942,9 @@ nickkill2done:
 	/* Set the vhost */
 	if (*virthost != '*')
 		safe_strdup(client->user->virthost, virthost);
+
+	/* Add to ipusers hash table (to track global maxperip) */
+	exceeds_maxperip(client, NULL);
 
 	build_umode_string(client, 0, SEND_UMODES|UMODE_SERVNOTICE, buf);
 
@@ -1063,7 +1293,7 @@ int _register_user(Client *client)
 	find_shun(client);
 
 	spamfilter_build_user_string(spamfilter_user, client->name, client);
-	if (match_spamfilter(client, spamfilter_user, SPAMF_USER, NULL, NULL, 0, NULL, &savetkl))
+	if (match_spamfilter(client, spamfilter_user, SPAMF_USER, NULL, NULL, 0, &savetkl))
 	{
 		if (savetkl &&
 		    (has_actions_of_type(savetkl->ptr.spamfilter->action, BAN_ACT_VIRUSCHAN) ||
@@ -1237,6 +1467,53 @@ void nick_collision(Client *cptr, const char *newnick, const char *newid, Client
 	}
 }
 
+/** Returns 1 if allow::maxperip is exceeded by 'client' */
+int exceeds_maxperip(Client *client, ConfigItem_allow *aconf)
+{
+	Client *acptr;
+	IpUsersBucket *bucket;
+
+	if (!client->ip)
+		return 0; /* eg. services */
+
+	bucket = find_ipusers_bucket(client);
+	if (!bucket)
+	{
+		client->flags |= CLIENT_FLAG_IPUSERS_BUMPED;
+		bucket = add_ipusers_bucket(client);
+		bucket->global_clients = 1;
+		if (MyConnect(client))
+			bucket->local_clients = 1;
+		return 0;
+	}
+
+	/* Bump if we haven't done so yet
+	 * (Actually not sure if this can ever be false, but...
+	 *  who knows with some 3rd party or some future change)
+	 */
+	if (!(client->flags & CLIENT_FLAG_IPUSERS_BUMPED))
+	{
+		bucket->global_clients++;
+		if (MyConnect(client))
+			bucket->local_clients++;
+		client->flags |= CLIENT_FLAG_IPUSERS_BUMPED;
+	}
+
+	if (find_tkl_exception(TKL_MAXPERIP, client))
+		return 0; /* exempt */
+
+	if (aconf)
+	{
+		if ((bucket->local_clients > aconf->maxperip) ||
+		    (bucket->global_clients > aconf->global_maxperip))
+		{
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
 /** Allow or reject the client based on allow { } blocks and all other restrictions.
  * @param client     Client to check (local)
  * @param username   Username, for some reason...
@@ -1250,7 +1527,6 @@ int AllowClient(Client *client)
 	char *hname;
 	static char uhost[HOSTLEN + USERLEN + 3];
 	static char fullname[HOSTLEN + 1];
-	Hook *h;
 
 	if (!IsSecure(client) && !IsLocalhost(client) && (iConf.plaintext_policy_user == POLICY_DENY))
 	{
@@ -1292,14 +1568,11 @@ int AllowClient(Client *client)
 		if (aconf->flags.useip)
 			set_sockhost(client, GetIP(client));
 
-		for (h = Hooks[HOOKTYPE_ALLOW_CLIENT]; h; h = h->next)
+		if (exceeds_maxperip(client, aconf))
 		{
-			const char *reject_reason = (*(h->func.stringfunc))(client, aconf);
-			if (reject_reason)
-			{
-				exit_client(client, NULL, reject_reason);
-				return 0;
-			}
+			/* Already got too many with that ip# */
+			exit_client(client, NULL, iConf.reject_message_too_many_connections);
+			return 0;
 		}
 
 		if (!((aconf->class->clients + 1) > aconf->class->maxclients))


### PR DESCRIPTION
Useful for my use-case with Runa, this lets modules block nick changes on an internal level. This is suitable for module-provided bots (like Runa) where this idea is better than the module adding a qline for the nick, which can be subsequently removed by an oper (using services or third-party mods) and potentially cause issues by `/nick`ing to the "internal" nick.