### PR TITLE
Add `HOOKTYPE_CAN_USE_NICK` to allow modules to reject certain nicks

### DIFF
--- a/include/modules.h
+++ b/include/modules.h
@@ -1314,6 +1314,8 @@ extern APICallback *APICallbackAdd(Module *module, APICallback *mreq);
 #define HOOKTYPE_ALLOW_CLIENT	126
 /** See hooktype_analyze_text */
 #define HOOKTYPE_ANALYZE_TEXT	127
+/** See hooktype_can_use_nick */
+#define HOOKTYPE_CAN_USE_NICK	128
 
 /* Adding a new hook here?
  * 1) Add the #define HOOKTYPE_.... with a new number
@@ -2454,6 +2456,15 @@ const char *hooktype_allow_client(Client *client, ConfigItem_allow *aconf);
  * @return The return value is ignored (use return 0)
  */
 int hooktype_analyze_text(Client *client, const char *text, TextAnalysis *e);
+
+/** Called when a user wants to change their nick
+ * @param client		The client
+ * @param newnick		The new nick the user wants to change to
+ * @param reject_reason	Pointer to a string that can be set to a reason why the nick change is rejected.
+ * @retval HOOK_DENY		Deny the nick change, set *reject_reason to a reason why it is denied.
+ * @retval HOOK_CONTINUE 	Allow the nick change, unless blocked by something else.
+*/
+int hooktype_can_use_nick(Client *client, const char *newnick, const char **reject_reason);
 /** @} */
 
 #ifdef GCC_TYPECHECKING
@@ -2583,7 +2594,8 @@ _UNREAL_ERROR(_hook_error_incompatible, "Incompatible hook function. Check argum
         ((hooktype == HOOKTYPE_SASL_AUTHENTICATE) && !ValidateHook(hooktype_sasl_authenticate, func)) || \
         ((hooktype == HOOKTYPE_SASL_MECHS) && !ValidateHook(hooktype_sasl_mechs, func)) || \
         ((hooktype == HOOKTYPE_ALLOW_CLIENT) && !ValidateHook(hooktype_allow_client, func)) || \
-        ((hooktype == HOOKTYPE_ANALYZE_TEXT) && !ValidateHook(hooktype_analyze_text, func))) \
+        ((hooktype == HOOKTYPE_ANALYZE_TEXT) && !ValidateHook(hooktype_analyze_text, func))) || \
+	((hooktype == HOOKTYPE_CAN_USE_NICK) && !ValidateHook(hooktype_can_use_nick, func))) \
         _hook_error_incompatible();
 #endif /* GCC_TYPECHECKING */
 

--- a/src/modules/nick.c
+++ b/src/modules/nick.c
@@ -301,7 +301,24 @@ CMD_FUNC(cmd_nick_local)
 
 	if (!ValidatePermissionsForPath("immune:nick-flood",client,NULL,NULL,NULL))
 		add_fake_lag(client, 3000);
-
+	
+	char *change_nick_error_from_hook = NULL;
+	for (h = Hooks[HOOKTYPE_CAN_USE_NICK]; h; h = h->next)
+	{
+		int ret = (*(h->func.intfunc))(client, nick, &change_nick_error_from_hook);
+		if (ret == HOOK_DENY)
+		{
+			if (change_nick_error_from_hook)
+			{
+				sendnumeric(client, ERR_ERRONEUSNICKNAME, nick, change_nick_error_from_hook);
+				safe_free(change_nick_error_from_hook);
+			} else {
+				sendnumeric(client, ERR_ERRONEUSNICKNAME, nick, "Denied by hook");
+			}
+			return;
+		}
+	}
+	
 	if ((acptr = find_client(nick, NULL)))
 	{
 		/* Shouldn't be possible since dot is disallowed: */


### PR DESCRIPTION
This is useful for my use-case where I want to block access to a specific nick "Runa" via module to a module-provided pseudo-client, similar to how "IRC" is blocked for internal use (CTCPs) but doesn't really exist as a client.