### PR TITLE
Update modules.optional.conf

### DIFF
--- a/doc/conf/modules.optional.conf
+++ b/doc/conf/modules.optional.conf
@@ -112,10 +112,11 @@ set {
 		 * Don't do antirandom checks for these users.
 		 */
 		except {
-			/* Exempt WEBIRC gateways because these frequently
+			/* Exempt WEBIRC and WEBSOCKET gateways because these frequently
 			 * cause false positives. So the default is yes.
 			 */
 			webirc yes;
+			websocket yes;
 
 			/* Exempt LAN users */
 			ip { 192.168.*; 127.*; }


### PR DESCRIPTION
Add `websocket` to the antirandom except list, since it will often trigger it because, by default (at least with KiwiIRC), the user ident will be the same as their nickname.