### PR TITLE
Adjust spamfilter:input-conversion to support 'deconfuse' as a synonym for 'confusables'

### DIFF
--- a/src/modules/tkl.c
+++ b/src/modules/tkl.c
@@ -281,7 +281,7 @@ int input_conversion_strtoval(const char *name)
 		return 0;
 	if (!strcmp(name, "strip-control-codes"))
 		return INPUT_CONVERSION_STRIP_CONTROL_CODES;
-	if (!strcmp(name, "confusables"))
+	if (!strcmp(name, "confusables") || !strcmp(name, "deconfuse"))
 		return INPUT_CONVERSION_CONFUSABLES;
 	return -1;
 }

--- a/src/modules/tkl.c
+++ b/src/modules/tkl.c
@@ -281,7 +281,7 @@ int input_conversion_strtoval(const char *name)
 		return 0;
 	if (!strcmp(name, "strip-control-codes"))
 		return INPUT_CONVERSION_STRIP_CONTROL_CODES;
-	if (!strcmp(name, "confusables") || !strcmp(name, "deconfuse"))
+	if (!strcmp(name, "deconfused") || !strcmp(name, "deconfuse") || !strcmp(name, "confusables"))
 		return INPUT_CONVERSION_CONFUSABLES;
 	return -1;
 }


### PR DESCRIPTION
Adjust input-conversion to support 'deconfuse' as a synonym for 'confusables', as the release notes imply that 'deconfuse' should be valid for spamfilter:input-conversion.