### PR TITLE
Fix issuer problem (doesn't show) in RPC TKLs

### DIFF
--- a/src/modules/rpc/name_ban.c
+++ b/src/modules/rpc/name_ban.c
@@ -144,7 +144,7 @@ RPC_CALL_FUNC(rpc_name_ban_del)
 
 	OPTIONAL_PARAM_STRING("set_by", set_by);
 	if (!set_by)
-		set_by = client->name;
+		set_by = client->rpc->issuer ? client->rpc->issuer : client->name;
 
 	if (!(tkl = my_find_tkl_nameban(name)))
 	{
@@ -208,7 +208,7 @@ RPC_CALL_FUNC(rpc_name_ban_add)
 
 	OPTIONAL_PARAM_STRING("set_by", set_by);
 	if (!set_by)
-		set_by = client->name;
+		set_by = client->rpc->issuer ? client->rpc->issuer : client->name;
 
 	if ((tkl_expire_at != 0) && (tkl_expire_at < TStime()))
 	{

--- a/src/modules/rpc/server_ban.c
+++ b/src/modules/rpc/server_ban.c
@@ -228,7 +228,7 @@ RPC_CALL_FUNC(rpc_server_ban_del)
 
 	OPTIONAL_PARAM_STRING("set_by", set_by);
 	if (!set_by)
-		set_by = client->name;
+		set_by = client->rpc->issuer ? client->rpc->issuer : client->name;
 
 	result = json_object();
 	json_expand_tkl(result, "tkl", tkl, 1);
@@ -309,7 +309,7 @@ RPC_CALL_FUNC(rpc_server_ban_add)
 
 	OPTIONAL_PARAM_STRING("set_by", set_by);
 	if (!set_by)
-		set_by = client->name;
+		set_by = client->rpc->issuer ? client->rpc->issuer : client->name;
 
 	if ((tkl_expire_at != 0) && (tkl_expire_at < TStime()))
 	{

--- a/src/modules/rpc/server_ban_exception.c
+++ b/src/modules/rpc/server_ban_exception.c
@@ -204,9 +204,10 @@ RPC_CALL_FUNC(rpc_server_ban_exception_del)
 		return;
 	}
 
+
 	OPTIONAL_PARAM_STRING("set_by", set_by);
 	if (!set_by)
-		set_by = client->name;
+		set_by = client->rpc->issuer ? client->rpc->issuer : client->name;
 
 	result = json_object();
 	json_expand_tkl(result, "tkl", tkl, 1);

--- a/src/modules/rpc/server_ban_exception.c
+++ b/src/modules/rpc/server_ban_exception.c
@@ -204,7 +204,6 @@ RPC_CALL_FUNC(rpc_server_ban_exception_del)
 		return;
 	}
 
-
 	OPTIONAL_PARAM_STRING("set_by", set_by);
 	if (!set_by)
 		set_by = client->rpc->issuer ? client->rpc->issuer : client->name;

--- a/src/modules/rpc/spamfilter.c
+++ b/src/modules/rpc/spamfilter.c
@@ -236,7 +236,7 @@ RPC_CALL_FUNC(rpc_spamfilter_add)
 
 	OPTIONAL_PARAM_STRING("set_by", set_by);
 	if (!set_by)
-		set_by = client->name;
+		set_by = client->rpc->issuer ? client->rpc->issuer : client->name;
 
 	if (find_tkl_spamfilter(type, name, action, targets))
 	{
@@ -293,7 +293,7 @@ RPC_CALL_FUNC(rpc_spamfilter_del)
 
 	OPTIONAL_PARAM_STRING("set_by", set_by);
 	if (!set_by)
-		set_by = client->name;
+		set_by = client->rpc->issuer ? client->rpc->issuer : client->name;
 
 	tkl = find_tkl_spamfilter(type, name, action, targets);
 	if (!tkl)


### PR DESCRIPTION
This was reported in #unreal-webpanel by @TehPeGaSuS 

Expected behavior was to show the issuer in places like this, but wasn't being shown.

This adds in the proper issuer when none is explicitly mentioned in the call, falling back to the `client->name`