### PR TITLE
message-tags: Fix length checks

### DIFF
--- a/src/modules/message-tags.c
+++ b/src/modules/message-tags.c
@@ -22,6 +22,10 @@
 
 #include "unrealircd.h"
 
+// https://ircv3.net/specs/extensions/message-tags#size-limit
+#define SERVER_SIZE_LIMIT 8191
+#define CLIENT_SIZE_LIMIT 4094
+
 ModuleHeader MOD_HEADER
   = {
 	"message-tags",
@@ -165,13 +169,10 @@ int message_tag_ok(Client *client, char *name, char *value)
 
 void _parse_message_tags(Client *client, char **str, MessageTag **mtag_list)
 {
-    // https://ircv3.net/specs/extensions/message-tags#size-limit
-    static unsigned int server_size_limit = 8191;
-    static unsigned int client_size_limit = 4094;
 
 	char *remainder;
 	char *element, *p, *x;
-	static char name[server_size_limit+1], value[server_size_limit+1];
+	static char name[SERVER_SIZE_LIMIT+1], value[SERVER_SIZE_LIMIT+1];
 	MessageTag *m;
 	int lenstr;
 
@@ -180,8 +181,8 @@ void _parse_message_tags(Client *client, char **str, MessageTag **mtag_list)
 		*remainder = '\0';
 
 	lenstr = strlen(*str);
-	if ((IsServer(client) && (lenstr > server_size_limit)) ||
-	    (!IsServer(client) && (lenstr > client_size_limit)))
+	if ((IsServer(client) && (lenstr > SERVER_SIZE_LIMIT)) ||
+	    (!IsServer(client) && (lenstr > CLIENT_SIZE_LIMIT)))
 	{
 		sendnumeric(client, ERR_INPUTTOOLONG);
 		remainder = NULL; /* stop parsing */

--- a/src/modules/message-tags.c
+++ b/src/modules/message-tags.c
@@ -165,9 +165,13 @@ int message_tag_ok(Client *client, char *name, char *value)
 
 void _parse_message_tags(Client *client, char **str, MessageTag **mtag_list)
 {
+    // https://ircv3.net/specs/extensions/message-tags#size-limit
+    static unsigned int server_size_limit = 8191;
+    static unsigned int client_size_limit = 4094;
+
 	char *remainder;
 	char *element, *p, *x;
-	static char name[8192], value[8192];
+	static char name[server_size_limit+1], value[server_size_limit+1];
 	MessageTag *m;
 	int lenstr;
 
@@ -176,8 +180,8 @@ void _parse_message_tags(Client *client, char **str, MessageTag **mtag_list)
 		*remainder = '\0';
 
 	lenstr = strlen(*str);
-	if ((IsServer(client) && (lenstr > 4094)) ||
-	    (!IsServer(client) && (lenstr > sizeof(name)-1)))
+	if ((IsServer(client) && (lenstr > server_size_limit)) ||
+	    (!IsServer(client) && (lenstr > client_size_limit)))
 	{
 		sendnumeric(client, ERR_INPUTTOOLONG);
 		remainder = NULL; /* stop parsing */

--- a/src/modules/message-tags.c
+++ b/src/modules/message-tags.c
@@ -23,8 +23,8 @@
 #include "unrealircd.h"
 
 // https://ircv3.net/specs/extensions/message-tags#size-limit
-#define SERVER_SIZE_LIMIT 8191
-#define CLIENT_SIZE_LIMIT 4094
+#define SERVER_TAG_SIZE_LIMIT 8191
+#define CLIENT_TAG_SIZE_LIMIT 4094
 
 ModuleHeader MOD_HEADER
   = {
@@ -172,7 +172,7 @@ void _parse_message_tags(Client *client, char **str, MessageTag **mtag_list)
 
 	char *remainder;
 	char *element, *p, *x;
-	static char name[SERVER_SIZE_LIMIT+1], value[SERVER_SIZE_LIMIT+1];
+	static char name[SERVER_TAG_SIZE_LIMIT+1], value[SERVER_TAG_SIZE_LIMIT+1];
 	MessageTag *m;
 	int lenstr;
 
@@ -181,8 +181,8 @@ void _parse_message_tags(Client *client, char **str, MessageTag **mtag_list)
 		*remainder = '\0';
 
 	lenstr = strlen(*str);
-	if ((IsServer(client) && (lenstr > SERVER_SIZE_LIMIT)) ||
-	    (!IsServer(client) && (lenstr > CLIENT_SIZE_LIMIT)))
+	if ((IsServer(client) && (lenstr > SERVER_TAG_SIZE_LIMIT)) ||
+	    (!IsServer(client) && (lenstr > CLIENT_TAG_SIZE_LIMIT)))
 	{
 		sendnumeric(client, ERR_INPUTTOOLONG);
 		remainder = NULL; /* stop parsing */


### PR DESCRIPTION
The fix in da703efdf44d2599233aad9445fd00666427eda5 was incorrect because it swapped the limits for clients and dservers