### PR TITLE
unreal_setfilemodtime: fix a Y2038 bug by replacing `Int32x32To64` with multiplication

### DIFF
--- a/src/support.c
+++ b/src/support.c
@@ -1123,7 +1123,7 @@ void unreal_setfilemodtime(const char *filename, time_t mtime)
 				  FILE_ATTRIBUTE_NORMAL, NULL);
 	if (hFile == INVALID_HANDLE_VALUE)
 		return;
-	llValue = Int32x32To64(mtime, 10000000) + 116444736000000000;
+	llValue = (mtime * 10000000LL) + 116444736000000000LL;
 	mTime.dwLowDateTime = (long)llValue;
 	mTime.dwHighDateTime = llValue >> 32;
 	


### PR DESCRIPTION
`Int32x32To64` macro internally truncates the arguments to int32, while `time_t` is 64-bit on most/all modern platforms. Therefore, usage of this macro creates a Year 2038 bug.

I detailed this issue a while ago in a writeup, and spotted the same issue in this repository when updating the list of affected repositories:
https://cookieplmonster.github.io/2022/02/17/year-2038-problem/