### PR TITLE
reply-tag, no-implicit-names: support ratified versions

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -1361,7 +1361,7 @@ MessageTag *duplicate_mtags(MessageTag *mtags)
 
 /** Duplicate a message tag list, excluding tags with MTAG_HANDLER_FLAGS_FIRST_ONLY.
  * Used to build the tag set for subsequent lines (lines 2..N),
- * where tags like msgid and +draft/reply should not be repeated.
+ * where tags like msgid, +reply and +draft/reply should not be repeated.
  */
 MessageTag *duplicate_mtags_for_subsequent_lines(MessageTag *mtags)
 {

--- a/src/modules/join.c
+++ b/src/modules/join.c
@@ -270,7 +270,7 @@ void _join_channel(Channel *channel, Client *client, MessageTag *recv_mtags, con
 		parv[0] = NULL;
 		parv[1] = channel->name;
 		parv[2] = NULL;
-		if (!HasCapability(client,"draft/no-implicit-names") /* && !HasCapability(client, "no-implicit-names") */)
+		if (!HasCapability(client,"draft/no-implicit-names") && !HasCapability(client, "no-implicit-names"))
 			do_cmd(client, NULL, "NAMES", 2, parv);;
 
 		unreal_log(ULOG_INFO, "join", "LOCAL_CLIENT_JOIN", client,

--- a/src/modules/no-implicit-names.c
+++ b/src/modules/no-implicit-names.c
@@ -40,24 +40,15 @@ MOD_INIT()
 
 	MARK_AS_OFFICIAL_MODULE(modinfo);
 
-	/** We only add the draft/ version for now */
 	memset(&cap, 0, sizeof(cap));
 	cap.name = NO_IMPLICIT_NAMES_CAP_DRAFT;
 	if (!ClientCapabilityAdd(modinfo->handle, &cap, &CAP_NO_IMPLICIT_NAMES_DRAFT))
-	{
 		return MOD_FAILED;
-	}
 
-	/** This is for the future :D
-	 * If you add this, then also update
-	 * _join_channel in src/modules/join.c to check for it,
-	 * as it is currently commented out there as well.
-	 */
-	/**
 	memset(&cap, 0, sizeof(cap));
 	cap.name = NO_IMPLICIT_NAMES_CAP;
-	ClientCapabilityAdd(modinfo->handle, &cap, &CAP_NO_IMPLICIT_NAMES);
-	*/
+	if (!ClientCapabilityAdd(modinfo->handle, &cap, &CAP_NO_IMPLICIT_NAMES))
+		return MOD_FAILED;
 
 	return MOD_SUCCESS;
 }

--- a/src/modules/reply-tag.c
+++ b/src/modules/reply-tag.c
@@ -42,13 +42,11 @@ MOD_INIT()
 
 	MARK_AS_OFFICIAL_MODULE(modinfo);
 
-#if 0
 	memset(&mtag, 0, sizeof(mtag));
 	mtag.name = "+reply";
 	mtag.is_ok = replytag_mtag_is_ok;
-	mtag.flags = MTAG_HANDLER_FLAGS_NO_CAP_NEEDED;
+	mtag.flags = MTAG_HANDLER_FLAGS_NO_CAP_NEEDED | MTAG_HANDLER_FLAGS_FIRST_ONLY;
 	MessageTagHandlerAdd(modinfo->handle, &mtag);
-#endif
 
 	memset(&mtag, 0, sizeof(mtag));
 	mtag.name = "+draft/reply";
@@ -98,14 +96,12 @@ void mtag_add_replytag(Client *client, MessageTag *recv_mtags, MessageTag **mtag
 
 	if (IsUser(client))
 	{
-#if 0
 		m = find_mtag(recv_mtags, "+reply");
 		if (m)
 		{
 			m = duplicate_mtag(m);
 			AddListItem(m, *mtag_list);
 		}
-#endif
 		m = find_mtag(recv_mtags, "+draft/reply");
 		if (m)
 		{


### PR DESCRIPTION
The IRCv3 specifications for these have been ratified:
- https://ircv3.net/specs/client-tags/reply
- https://ircv3.net/specs/extensions/no-implicit-names

Both the draft and ratified names are now supported for the transition period. Neither draft form is removed.

reply-tag.c:
- Register +reply handler (ratified) alongside +draft/reply
- Both carry MTAG_HANDLER_FLAGS_FIRST_ONLY so neither propagates to subsequent lines of a multiline message
- mtag_add_replytag propagates whichever form the client sent

no-implicit-names.c:
- Register no-implicit-names CAP (ratified) alongside draft/no-implicit-names
- Both are active; clients may negotiate either

join.c:
- _join_channel now suppresses the implicit NAMES reply when the client has negotiated either draft/no-implicit-names or no-implicit-names