### PR TITLE
chathistory: implement draft/chathistory-end tag

### DIFF
--- a/include/h.h
+++ b/include/h.h
@@ -1218,7 +1218,7 @@ extern HistoryResult *history_request(const char *object, HistoryFilter *filter)
 extern int history_delete(const char *object, HistoryFilter *filter, int *rejected_deletes);
 extern int history_destroy(const char *object);
 extern int can_receive_history(Client *client);
-extern void history_send_result(Client *client, HistoryResult *r);
+extern void history_send_result(Client *client, HistoryResult *r, int end_of_pagination);
 extern void free_history_result(HistoryResult *r);
 extern void free_history_filter(HistoryFilter *f);
 extern void special_delayed_unloading(void);

--- a/src/api-history-backend.c
+++ b/src/api-history-backend.c
@@ -374,11 +374,12 @@ static void history_send_result_multiline_fallback(Client *client, HistoryLogLin
  * @param client	The client to send to.
  * @param r		The history result retrieved via history_request().
  */
-void history_send_result(Client *client, HistoryResult *r)
+void history_send_result(Client *client, HistoryResult *r, int end_of_pagination)
 {
 	char batch[BATCHLEN+1];
 	HistoryLogLine *l;
 	int has_multiline;
+	MessageTag *batch_open_mtags = NULL;
 
 	if (!can_receive_history(client))
 		return;
@@ -388,7 +389,14 @@ void history_send_result(Client *client, HistoryResult *r)
 	{
 		/* Start a new batch */
 		generate_batch_id(batch);
-		sendto_one(client, NULL, ":%s BATCH +%s chathistory %s", me.name, batch, r->object);
+		if (end_of_pagination)
+		{
+			batch_open_mtags = safe_alloc(sizeof(MessageTag));
+			safe_strdup(batch_open_mtags->name, "draft/chathistory-end");
+		}
+		sendto_one(client, batch_open_mtags, ":%s BATCH +%s chathistory %s", me.name, batch, r->object);
+		if (batch_open_mtags)
+			free_message_tags(batch_open_mtags);
 	}
 
 	has_multiline = HasCapability(client, "draft/multiline") && HasCapability(client, "batch");

--- a/src/modules/chanmodes/history.c
+++ b/src/modules/chanmodes/history.c
@@ -740,7 +740,7 @@ int history_join(Client *client, Channel *channel, MessageTag *mtags)
 		r = history_request(channel->name, &filter);
 		if (r)
 		{
-			history_send_result(client, r);
+			history_send_result(client, r, 0);
 			free_history_result(r);
 		}
 	}

--- a/src/modules/chathistory.c
+++ b/src/modules/chathistory.c
@@ -26,6 +26,7 @@ struct ChatHistoryTarget {
 
 /* Forward declarations */
 CMD_FUNC(cmd_chathistory);
+int chathistory_end_mtag_is_ok(Client *client, const char *name, const char *value);
 
 /* Global variables */
 long CAP_CHATHISTORY = 0L;
@@ -35,13 +36,22 @@ long CAP_CHATHISTORY = 0L;
 MOD_INIT()
 {
 	ClientCapabilityInfo c;
+	ClientCapability *cap;
+	MessageTagHandlerInfo mtag;
 
 	MARK_AS_OFFICIAL_MODULE(modinfo);
 	CommandAdd(modinfo->handle, "CHATHISTORY", cmd_chathistory, MAXPARA, CMD_USER);
 
 	memset(&c, 0, sizeof(c));
 	c.name = "draft/chathistory";
-	ClientCapabilityAdd(modinfo->handle, &c, &CAP_CHATHISTORY);
+	cap = ClientCapabilityAdd(modinfo->handle, &c, &CAP_CHATHISTORY);
+
+	memset(&mtag, 0, sizeof(mtag));
+	mtag.name = "draft/chathistory-end";
+	mtag.is_ok = chathistory_end_mtag_is_ok;
+	mtag.clicap_handler = cap;
+	MessageTagHandlerAdd(modinfo->handle, &mtag);
+
 	return MOD_SUCCESS;
 }
 
@@ -55,6 +65,14 @@ MOD_LOAD()
 MOD_UNLOAD()
 {
 	return MOD_SUCCESS;
+}
+
+/** The draft/chathistory-end tag is server-generated only; reject it from clients */
+int chathistory_end_mtag_is_ok(Client *client, const char *name, const char *value)
+{
+	if (IsServer(client))
+		return 1;
+	return 0;
 }
 
 int chathistory_token(const char *str, char *token, char **store)
@@ -188,14 +206,30 @@ void chathistory_targets(Client *client, HistoryFilter *filter, int limit)
 
 	/* 2. Now send it to the client */
 
+	/* Count total matching targets to determine end-of-pagination */
+	{
+		ChatHistoryTarget *t;
+		for (t = targets; t; t = t->next)
+			sent++;
+	}
+
 	batch[0] = '\0';
 	if (HasCapability(client, "batch"))
 	{
 		/* Start a new batch */
+		MessageTag *batch_open_mtags = NULL;
 		generate_batch_id(batch);
-		sendto_one(client, NULL, ":%s BATCH +%s draft/chathistory-targets", me.name, batch);
+		if (sent < limit)
+		{
+			batch_open_mtags = safe_alloc(sizeof(MessageTag));
+			safe_strdup(batch_open_mtags->name, "draft/chathistory-end");
+		}
+		sendto_one(client, batch_open_mtags, ":%s BATCH +%s draft/chathistory-targets", me.name, batch);
+		if (batch_open_mtags)
+			free_message_tags(batch_open_mtags);
 	}
 
+	sent = 0;
 	for (; targets; targets = targets_next)
 	{
 		targets_next = targets->next;
@@ -418,7 +452,17 @@ CMD_FUNC(cmd_chathistory)
 			if (fakelag_ms > 5000)
 				fakelag_ms = 5000;
 			add_fake_lag(client, fakelag_ms);
-			history_send_result(client, r);
+			/* Count logical messages to determine end-of-pagination.
+			 * Each entry in r->log is a head message (multiline continuation
+			 * lines are linked via next_in_batch, not next).
+			 */
+			{
+				HistoryLogLine *l;
+				int count = 0;
+				for (l = r->log; l; l = l->next)
+					count++;
+				history_send_result(client, r, count < filter->limit);
+			}
 		}
 	}
 

--- a/src/modules/history.c
+++ b/src/modules/history.c
@@ -130,7 +130,7 @@ CMD_FUNC(cmd_history)
 
 	if ((r = history_request(channel->name, &filter)))
 	{
-		history_send_result(client, r);
+		history_send_result(client, r, 0);
 		free_history_result(r);
 	}
 }


### PR DESCRIPTION
This is a recent [spec modification suggestion](https://github.com/ircv3/ircv3-specifications/pull/598) which I agree is a nice touch, I'm not leaving this as a draft like the [other PR](https://github.com/unrealircd/unrealircd/pull/334) because I think this one will have virtually no impact whatsoever if implemented immediately.

This implements a new tag on a batch when the batch is the final batch of a chathistory request, as in "this batch contains the final message in the chathistory so there are no more messages to send, so you can stop requesting more/hide UI button for viewing more messages"